### PR TITLE
Added 'coffee' to executables in env test

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -3,7 +3,7 @@
 exports.isNode = 'undefined' != typeof process
            && 'object' == typeof module
            && process.argv
-           && /node/.test(process.argv[0]);
+           && /node|coffee/.test(process.argv[0]);
 
 exports.isMongo = !exports.isNode
            && 'function' == typeof printjson


### PR DESCRIPTION
I couldn't run mongoose/mquery without this modification. I'm running node from coffee script, so the executable name is not 'node', but 'coffee'.

Not sure if there is a need to add conf entry for defining your own executable, so this quick fix should do it for most cases.
