### PR TITLE
Fix Mongo DB Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "sliced": "0.0.5",
     "debug": "0.7.0",
+    "mongodb": "1.3.x",
     "regexp-clone": "0.0.1"
   },
   "devDependencies": {
-    "mocha": "1.9.x",
-    "mongodb": "1.3.x"
+    "mocha": "1.9.x"
   },
   "bugs": {
     "url":"https://github.com/aheckmann/mquery/issues/new"


### PR DESCRIPTION
`utils.js` needs mongodb, so it actually should be an actual dependency, unless I am missing something? Right now I've needed to npm install manually to get working.
