### PR TITLE
Remove mongodb driver dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,8 +839,8 @@ mquery().read('sp') // same as secondaryPreferred
 mquery().read('nearest')
 mquery().read('n')  // same as nearest
 
-// specifying tags
-mquery().read('s', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }])
+// you can also use mongodb.ReadPreference class to also specify tags
+mquery().read(mongodb.ReadPreference('secondary', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }]))
 ```
 
 #####Preferences:
@@ -859,7 +859,7 @@ Aliases
 - `sp`  secondaryPreferred
 - `n`   nearest
 
-Read more about how to use read preferrences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
+Read more about how to use read preferences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
 
 ###slaveOk()
 

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1426,12 +1426,12 @@ Query.prototype.slaveOk = function (v) {
  *     new Query().read('nearest')
  *     new Query().read('n')  // same as nearest
  *
- *     // with tags
- *     new Query().read('s', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }])
+ *     // you can also use mongodb.ReadPreference class to also specify tags
+ *     new Query().read(mongodb.ReadPreference('secondary', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }]))
  *
  * ####Preferences:
  *
- *     primary - (default) Read from primary only. Operations will produce an error if primary is unavailable. Cannot be combined with tags.
+ *     primary - (default)  Read from primary only. Operations will produce an error if primary is unavailable. Cannot be combined with tags.
  *     secondary            Read from secondary if available, otherwise error.
  *     primaryPreferred     Read from primary if available, otherwise a secondary.
  *     secondaryPreferred   Read from a secondary if available, otherwise read from the primary.
@@ -1445,18 +1445,17 @@ Query.prototype.slaveOk = function (v) {
  *     sp  secondaryPreferred
  *     n   nearest
  *
- * Read more about how to use read preferrences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
+ * Read more about how to use read preferences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
  *
- * @param {String} pref one of the listed preference options or their aliases
- * @param {Array} [tags] optional tags for this query
+ * @param {String|ReadPreference} pref one of the listed preference options or their aliases
  * @see mongodb http://docs.mongodb.org/manual/applications/replication/#read-preference
  * @see driver http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences
  * @return {Query} this
  * @api public
  */
 
-Query.prototype.read = function (pref, tags) {
-  this.options.readPreference = utils.readPref(pref, tags);
+Query.prototype.read = function (pref) {
+  this.options.readPreference = utils.readPref(pref);
   return this;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,10 +4,7 @@
  * Module dependencies.
  */
 
-var mongodb = require('mongodb')
-  , ReadPref = mongodb.ReadPreference
-  , ObjectId = mongodb.ObjectID
-  , RegExpClone = require('regexp-clone')
+var RegExpClone = require('regexp-clone')
 
 /**
  * Object clone with Mongoose natives support.
@@ -35,12 +32,11 @@ exports.clone = function clone (obj, options) {
   if ('Date' === obj.constructor.name || 'Function' === obj.constructor.name)
     return new obj.constructor(+obj);
 
-  if ('RegExp' === obj.constructor.name) {
+  if ('RegExp' === obj.constructor.name)
     return RegExpClone(obj);
-  }
 
-  if (obj instanceof ObjectId)
-    return new ObjectId(obj.id);
+  if ('ObjectId' === obj.constructor.name)
+    return new obj.constructor(obj.id);
 
   if (obj.valueOf)
     return obj.valueOf();
@@ -197,16 +193,10 @@ var mergeClone = exports.mergeClone = function mergeClone (to, from) {
  *     sp  secondaryPreferred
  *     n   nearest
  *
- * @param {String|Array} pref
- * @param {Array} [tags]
+ * @param {String} pref
  */
 
-exports.readPref = function readPref (pref, tags) {
-  if (Array.isArray(pref)) {
-    tags = pref[1];
-    pref = pref[0];
-  }
-
+exports.readPref = function readPref (pref) {
   switch (pref) {
     case 'p':
       pref = 'primary';
@@ -225,7 +215,7 @@ exports.readPref = function readPref (pref, tags) {
       break;
   }
 
-  return new ReadPref(pref, tags);
+  return pref;
 }
 
 /**
@@ -312,8 +302,3 @@ var soon = exports.soon = 'function' == typeof setImmediate
   ? setImmediate
   : process.nextTick;
 
-/**
- * need to export this for checking issues
- */
-
-exports.mongo = mongodb;

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "sliced": "0.0.5",
     "debug": "0.7.4",
-    "mongodb": "1.3.19",
     "regexp-clone": "0.0.1"
   },
   "devDependencies": {
+    "mongodb": "1.3.x",
     "mocha": "1.9.x"
   },
   "bugs": {

--- a/test/index.js
+++ b/test/index.js
@@ -1237,7 +1237,7 @@ describe('mquery', function(){
     it('sets associated readPreference option', function(){
       var m = mquery();
       m.read('p');
-      assert.equal('primary', m.options.readPreference.mode);
+      assert.equal('primary', m.options.readPreference);
     })
     it('is chainable', function(){
       var m = mquery();


### PR DESCRIPTION
See more discussion in #25.

mongodb.ObjectId class was needed to clone existing ObjectId. Now we just use
obj.constructor of the old ObjectId.

mongodb.ReadPreference is more difficult. It's used to create a readPreference
option in queries.

Our options are:
1. We could try to keep the same semantics and save this class on mquery
   initialization, something like `mquery = require('mquery')(mongodb)`.
   This is deemed too serious change for such a small cause.
2. We could try to get it from a collection, but 1) it seems that this class
   is not exported by collection and 2) this would violate the collection
   abstraction infrastructure of mquery (lib/collection folder).
3. As mongo driver accepts both string representation of read preference and
   an instance of ReadPreference class, we could work with just strings. This
   way, user can keep using short string representation when the tags are not
   needed (in majority of cases), and provide an instance of ReadPreference
   class when tags are required. It's also future-proof as mongo driver can
   add other options to ReadPreference class and users will be able to use
   them right away. This last option is implemented.
