### PR TITLE
Make deprecation notice for unsupported 'tags' parameter of Query.read() method.

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1455,6 +1455,10 @@ Query.prototype.slaveOk = function (v) {
  */
 
 Query.prototype.read = function (pref) {
+  if (arguments.length > 1 && !Query.prototype.read.deprecationWarningIssued) {
+    console.error("Deprecation warning: 'tags' argument is not supported anymore in Query.read() method. Please use mongodb.ReadPreference object instead.");
+    Query.prototype.read.deprecationWarningIssued = true;
+  }
   this.options.readPreference = utils.readPref(pref);
   return this;
 }


### PR DESCRIPTION
I thought it would be nice to add a deprecation notice to stderr for people not reading all changelogs, what do you think?
