### PR TITLE
Use fixed mongodb version, fixes learnboost/mongoose#1895

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "regexp-clone": "0.0.1"
   },
   "devDependencies": {
-    "mongodb": "1.3.x",
+    "mongodb": "1.3.23",
     "mocha": "1.9.x"
   },
   "bugs": {


### PR DESCRIPTION
Apparently `1.3.19` `readPreference` objects aren't the same as `1.3.23`'s `readPreference`.  Changing this version fixes the problem.
