### PR TITLE
Added correct cloning of ReadPreferences.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,11 +23,14 @@ var clone = exports.clone = function clone (obj, options) {
     return exports.cloneArray(obj, options);
 
   if (obj.constructor) {
-    if (/ObjectI[dD]{1}/.test(obj.constructor.name)) {
+    if (/ObjectI[dD]/.test(obj.constructor.name)) {
       return 'function' == typeof obj.clone
         ? obj.clone()
         : new obj.constructor(obj.id);
     }
+
+    if ('ReadPreference' === obj._type && obj.isValid && obj.toObject)
+        return new obj.constructor(obj.mode, clone(obj.tags, options));
 
     if ('Date' === obj.constructor.name || 'Function' === obj.constructor.name)
       return new obj.constructor(+obj);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,6 +1,7 @@
 
 var utils = require('../lib/utils');
 var assert = require('assert');
+var mongo = require('mongodb');
 
 describe('lib/utils', function() {
   describe('clone', function() {
@@ -49,6 +50,33 @@ describe('lib/utils', function() {
       assert.ok(o2 instanceof ObjectID);
       assert.equal(id, o2.id);
       assert.ok(o2.cloned);
+      done();
+    });
+
+    it('clones mongodb.ReadPreferences', function(done) {
+      var tags = [{dc: 'tag1'}];
+      var prefs = [
+        new mongo.ReadPreference("primary"),
+        new mongo.ReadPreference(mongo.ReadPreference.PRIMARY_PREFERRED),
+        new mongo.ReadPreference("primary", tags),
+        mongo.ReadPreference("primary", tags)
+      ];
+
+      var prefsCloned = utils.clone(prefs);
+      
+      for (var i = 0; i < prefsCloned.length; i++) {
+        assert.notEqual(prefs[i], prefsCloned[i]);
+        assert.ok(prefsCloned[i] instanceof mongo.ReadPreference);
+        assert.ok(prefsCloned[i].isValid());
+        if (prefs[i].tags) {
+          assert.ok(prefsCloned[i].tags);
+          assert.notEqual(prefs[i].tags, prefsCloned[i].tags);
+          assert.notEqual(prefs[i].tags[0], prefsCloned[i].tags[0]);
+        } else {
+          assert.equal(prefsCloned[i].tags, null);
+        }
+      }
+
       done();
     });
 


### PR DESCRIPTION
Fixes #30.
Problem was with cloning `options.readPreference` in `Query#_optionsForExec()`.
It was cloned to a simple object, which didn't work well with Mongo driver.
Now it is cloned to another ReadPreference object.

Test added.

Also removed unnecessary `{1}` from ObjectId checking regexp.
