### PR TITLE
Allow $meta args in sort() so text search sorting works

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1202,6 +1202,12 @@ Query.prototype.sort = function (arg) {
  */
 
 function push (opts, field, value) {
+  if (value && typeof value === 'object' && value.$meta) {
+    var s = opts.sort || (opts.sort = {});
+    s[field] = { $meta : value.$meta };
+    return;
+  }
+
   var val = String(value || 1).toLowerCase();
   if (!/^(?:ascending|asc|descending|desc|1|-1)$/.test(val)) {
     if (utils.isArray(value)) value = '['+value+']';
@@ -1214,7 +1220,7 @@ function push (opts, field, value) {
                   .replace("ascending", "1")
                   .replace("desc", "-1")
                   .replace("descending", "-1");
-  s[field] = parseInt(valueStr);
+  s[field] = parseInt(valueStr, 10);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -1135,9 +1135,15 @@ describe('mquery', function(){
       assert.equal(e.message, 'Invalid sort() argument. Must be a string or object.');
     })
 
+    it('handles $meta sort options', function(){
+      var query = mquery();
+      query.sort({ score: { $meta : "textScore" } });
+      assert.deepEqual(query.options.sort, { score : { $meta : "textScore" } });
+    })
+
     no('count', 'sort');
   })
-
+  
   function simpleOption (type) {
     describe(type, function(){
       it('sets the ' + type + ' option', function(){


### PR DESCRIPTION
Hey Aaron,

Ran into this issue while trying to do text search with Mongoose. Sorting by text search score as described in http://docs.mongodb.org/master/reference/operator/query/text/#op._S_text doesn't work right now in mquery, or by extension Mongoose, against MongoDB 2.6.0-rc2. Would be nice for this to work for the MongoDB 2.6.0 release.
