### PR TITLE
Merge conditions with $and

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1517,7 +1517,7 @@ Query.prototype.merge = function (source) {
     // if source has a feature, apply it to ourselves
 
     if (source._conditions) {
-      utils.merge(this._conditions, source._conditions);
+      utils.mergeConditions(this._conditions, source._conditions);
     }
 
     if (source._fields) {
@@ -1543,7 +1543,7 @@ Query.prototype.merge = function (source) {
   }
 
   // plain object
-  utils.merge(this._conditions, source);
+  utils.mergeConditions(this._conditions, source);
 
   return this;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,6 +163,41 @@ var merge = exports.merge = function merge (to, from) {
   }
 }
 
+var mergeConditions = exports.mergeConditions = function mergeConditions(to,from){
+  var keys = Object.keys(from)
+    , i = keys.length
+    , key
+
+  while (i--) {
+    key = keys[i];
+    var c2 = {};
+    c2[key] = from[key];
+
+    if ('undefined' === typeof to[key]) {
+      for (var j = 0; to.$and && j < to.$and.length; j++) {
+        if ('undefined' !== typeof to.$and[j][key]) {
+          to.$and.push(c2);
+          return;
+        }
+      }
+
+      to[key] = from[key];
+    } else if (key === '$and') {
+      to.$and = to.$and.concat(from.$and);
+    } else {
+      var c1 = {};
+      c1[key] = to[key];
+
+      if (to.$and && to.$and.length) {
+        to.$and.push(c1,c2);
+      } else {
+        to.$and = [c1,c2];
+      }
+      delete to[key];
+    }
+  }
+}
+
 /**
  * Same as merge but clones the assigned values.
  *

--- a/test/index.js
+++ b/test/index.js
@@ -153,7 +153,7 @@ describe('mquery', function(){
         var m = mquery({ name: 'first' });
         var n = mquery({ name: 'changed' });
         m.where(n);
-        assert.strictEqual(m._conditions.name, 'changed');
+        assert.strictEqual(m._conditions.$and[1].name, 'changed');
       })
       it('that is a string', function(){
         var m = mquery();
@@ -1363,7 +1363,17 @@ describe('mquery', function(){
       assert.deepEqual(m._conditions, {x:1,y:2});
     })
 
-    it('merges other queries', function(){
+    it('merges conditions\' matching properties with $and',function(){
+      var m = mquery().find({z:1}).find({x:1}).find({y:1}).find({x:2}).find({y:2}).find({x:3});
+      assert.deepEqual(m._conditions,{z:1, $and:[{x:1},{x:2},{y:1},{y:2},{x:3}]});
+    })
+
+    it('merges $and condition',function(){
+      var m = mquery().find({z:1,}).find({$and:[{x:1}]}).find({$and:[{x:2}]});
+      assert.deepEqual(m._conditions,{z:1, $and:[{x:1},{x:2}]});
+    })
+
+	it('merges other queries', function(){
       var m = mquery({ name: 'mquery' });
       m.tailable();
       m.select('_id');
@@ -2362,7 +2372,7 @@ describe('mquery', function(){
         it('updates the doc', function(){
           var m = mquery({ name: name });
           var n = m.findOneAndRemove(m);
-          assert.deepEqual(n._conditions, { name: name });
+          assert.deepEqual(n._conditions, { $and:[{ name: name },{ name: name }]});
         })
       })
       it('that is a function', function(done){


### PR DESCRIPTION
So that prior conditions are not ignored, merge any conditions for the same property with $and.
(issue #38)
