### PR TITLE
Remove broken require() calls until they're actually implemented

### DIFF
--- a/lib/collection/index.js
+++ b/lib/collection/index.js
@@ -8,6 +8,6 @@ if ('unknown' == env.type) {
 
 module.exports =
   env.isNode ? require('./node') :
-  env.isMongo ? require('./mongo') :
-  require('./browser');
+  env.isMongo ? require('./collection') :
+  require('./collection');
 


### PR DESCRIPTION
Hi Aaron,

Love the work you're doing with making mquery browser and mongo shell friendly, but some work I'm doing with mongoose and browserify is getting blown up by attempts to `require()` nonexistent files. Can we remove these `require()` calls until there's a reasonable implementation?
