### PR TITLE
Add setTraceFunction() method to query

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ require('mongodb').connect(uri, function (err, db) {
 - [thunk](#thunk)
 - [merge](#mergeobject)
 - [setOptions](#setoptionsoptions)
+- [setTraceFunction](#settracefunctionfunc)
+- [mquery.setGlobalTraceFunction](#mquerysetglobaltracefunctionfunc)
 - [mquery.canMerge](#mquerycanmerge)
 - [mquery.use$geoWithin](#mqueryusegeowithin)
 
@@ -1088,6 +1090,46 @@ mquery().setOptions({ collection: coll, limit: 20 })
 - [collection](#collection): the collection to query against
 
 _* denotes a query helper method is also available_
+
+###setTraceFunction(func)
+
+Set a function to trace this query. Useful for profiling or logging.
+
+```js
+function traceFunction (method, queryInfo, query) {
+  console.log('starting ' + method + ' query');
+
+  return function (err, result, millis) {
+    console.log('finished ' + method + ' query in ' + millis + 'ms');
+  };
+}
+
+mquery().setTraceFunction(traceFunction).findOne({name: 'Joe'}, cb);
+```
+
+The trace function is passed (method, queryInfo, query)
+
+- method is the name of the method being called (e.g. findOne)
+- queryInfo contains information about the query:
+ - conditions: query conditions/criteria
+ - options: options such as sort, fields, etc
+ - doc: document being updated
+- query is the query object
+
+The trace function should return a callback function which accepts:
+- err: error, if any
+- result: result, if any
+- millis: time spent waiting for query result
+
+NOTE: stream requests are not traced.
+
+###mquery.setGlobalTraceFunction(func)
+
+Similar to `setTraceFunction()` but automatically applied to all queries.
+
+```js
+mquery.setTraceFunction(traceFunction);
+```
 
 ###mquery.canMerge(conditions)
 

--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -9,6 +9,7 @@ var utils = require('../utils');
 
 function NodeCollection (col) {
   this.collection = col;
+  this.collectionName = col.collectionName;
 }
 
 /**

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -50,6 +50,7 @@ function Query (criteria, options) {
   this._path = proto._path || undefined;
   this._distinct = proto._distinct || undefined;
   this._collection = proto._collection || undefined;
+  this._traceFunction = proto._traceFunction || undefined;
 
   if (options) {
     this.setOptions(options);
@@ -135,6 +136,7 @@ Query.prototype.toConstructor = function toConstructor () {
   p._path = this._path;
   p._distinct = this._distinct;
   p._collection = this._collection;
+  p._traceFunction = this._traceFunction;
 
   return CustomQuery;
 }
@@ -1610,6 +1612,10 @@ Query.prototype.find = function (criteria, callback) {
   options.fields = this._fieldsForExec()
 
   debug('find', conds, options);
+  callback = this._wrapCallback('find', callback, {
+    conditions: conds
+  , options: options
+  });
 
   this._collection.find(conds, options, utils.tick(callback));
   return this;
@@ -1661,6 +1667,11 @@ Query.prototype.findOne = function (criteria, callback) {
   options.fields = this._fieldsForExec();
 
   debug('findOne', conds, options);
+  callback = this._wrapCallback('findOne', callback, {
+    conditions: conds
+  , options: options
+  });
+
   this._collection.findOne(conds, options, utils.tick(callback));
 
   return this;
@@ -1708,6 +1719,11 @@ Query.prototype.count = function (criteria, callback) {
     , options = this._optionsForExec()
 
   debug('count', conds, options);
+  callback = this._wrapCallback('count', callback, {
+    conditions: conds
+  , options: options
+  });
+
   this._collection.count(conds, options, utils.tick(callback));
   return this;
 }
@@ -1787,6 +1803,11 @@ Query.prototype.distinct = function (criteria, field, callback) {
     , options = this._optionsForExec()
 
   debug('distinct', conds, options);
+  callback = this._wrapCallback('distinct', callback, {
+    conditions: conds
+  , options: options
+  });
+
   this._collection.distinct(this._distinct, conds, options, utils.tick(callback));
 
   return this;
@@ -1936,6 +1957,12 @@ Query.prototype.update = function update (criteria, doc, options, callback) {
   doc = this._updateForExec();
 
   debug('update', criteria, doc, options);
+  callback = this._wrapCallback('update', callback, {
+    conditions: criteria
+  , doc: doc
+  , options: options
+  });
+
   this._collection.update(criteria, doc, options, utils.tick(callback));
 
   return this;
@@ -1997,6 +2024,11 @@ Query.prototype.remove = function (criteria, callback) {
   var conds = this._conditions;
 
   debug('remove', conds, options);
+  callback = this._wrapCallback('remove', callback, {
+    conditions: conds
+  , options: options
+  });
+
   this._collection.remove(conds, options, utils.tick(callback));
 
   return this;
@@ -2170,10 +2202,72 @@ Query.prototype._findAndModify = function (type, callback) {
   var conds = this._conditions;
 
   debug('findAndModify', conds, doc, opts);
+  callback = this._wrapCallback('findAndModify', callback, {
+    conditions: conds
+  , doc: doc
+  , options: opts
+  });
 
   this._collection
   .findAndModify(conds, doc, opts, utils.tick(callback));
 
+  return this;
+}
+
+/**
+ * Wrap callback to add tracing
+ *
+ * @param {Function} callback
+ * @param {Object} [queryInfo]
+ * @api private
+ */
+Query.prototype._wrapCallback = function (method, callback, queryInfo) {
+  var traceFunction = this._traceFunction || Query.traceFunction;
+
+  if (traceFunction) {
+    queryInfo.collectionName = this._collection.collectionName;
+
+    var traceCallback = traceFunction &&
+      traceFunction.call(null, method, queryInfo, this);
+
+    var startTime = new Date().getTime();
+
+    return function wrapperCallback (err, result) {
+      if (traceCallback) {
+        var millis = new Date().getTime() - startTime;
+        traceCallback.call(null, err, result, millis);
+      }
+
+      if (callback) {
+        callback.apply(null, arguments);
+      }
+    };
+  }
+
+  return callback;
+}
+
+/**
+ * Add trace function that gets called when the query is executed.
+ * The function will be called with (method, queryInfo, query) and
+ * should return a callback function which will be called
+ * with (err, result, millis) when the query is complete.
+ *
+ * queryInfo is an object containing: {
+ *   collectionName: <name of the collection>,
+ *   conditions: <query criteria>,
+ *   options: <comment, fields, readPreference, etc>,
+ *   doc: [document to update, if applicable]
+ * }
+ *
+ * NOTE: Does not trace stream queries.
+ *
+ * @param {Function} traceFunction
+ * @return {Query} this
+ * @api public
+ */
+Query.prototype.setTraceFunction = function (traceFunction) {
+  this._traceFunction = traceFunction;
   return this;
 }
 
@@ -2476,6 +2570,19 @@ Query.canMerge = function (conds) {
   return conds instanceof Query || utils.isObject(conds);
 }
 
+/**
+ * Set a trace function that will get called whenever a
+ * query is executed.
+ *
+ * See `setTraceFunction()` for details.
+ *
+ * @param {Object} conds
+ * @return {Boolean}
+ */
+Query.setGlobalTraceFunction = function (traceFunction) {
+  Query.traceFunction = traceFunction;
+}
+
 /*!
  * Exports.
  */
@@ -2489,3 +2596,4 @@ module.exports = exports = Query;
 
 // TODO
 // test utils
+


### PR DESCRIPTION
This allows the developer to track when a query starts and ends
for logging/timing/debugging purposes. There is also a global
Query.setGlobalTraceFunction() that applies the trace function
to all queries.

The trace function is passed information about the query, and is
expected to return a function that will be called with information
about the result.
