### PR TITLE
Compatibility issue with monk (or possibly mongodriver 2.x or both)

### DIFF
--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -26,7 +26,14 @@ NodeCollection.prototype.find = function (match, options, cb) {
   this.collection.find(match, options, function (err, cursor) {
     if (err) return cb(err);
 
-    cursor.toArray(cb);
+    // When used with monk the result was allready an array so
+    // checking for that:
+    if (cursor.toArray) {
+        cursor.toArray(cb);
+    } else {
+        cb(undefined, cursor);
+    }
+    
   });
 }
 

--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -28,10 +28,10 @@ NodeCollection.prototype.find = function (match, options, cb) {
 
     // When used with monk the result was allready an array so
     // checking for that:
-    if (cursor.toArray) {
-        cursor.toArray(cb);
-    } else {
+    if (Array.isArray(cursor)) {
         cb(undefined, cursor);
+    } else {
+        cursor.toArray(cb);
     }
     
   });


### PR DESCRIPTION
I used mquery with monk and it complained when performing a query. The returned result was an array and not a cursor, so we can't convert it into an arrray again.