### PR TITLE
Do not override `resolve` and `reject` functions with null

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -2346,7 +2346,6 @@ Query.prototype.then = function(resolve, reject) {
   var self = this;
   var promise = new Query.Promise(function(success, error) {
     self.exec(function(err, val) {
-      self = resolve = reject = null;
       if (err) return error(err);
       success(val);
     });


### PR DESCRIPTION
Promise resolver, the `function(success, error)`, is called synchronously. This is documented behavior of `bluebird`. However callback passed to `self.exec` is expected to be called asynchronously, but it is actually called synchronously in case of `CastError` (happening on mongoose side).

Calling callback passed to `self.exec` asynchronously will require careful refactoring, leaving the root cause aside, we can fix one use case right now with small change. I propose to remove setting `resolve` and `reject` to null as a fix for this use case, as it does not make sense to null them: these variables are not accessible from callback scope, thus they will not be put in environment when executing callback, so they will be eventually cleared by GC.

Consider following mongoose code:

```
Model.findOne({ numericProperty: '1a' }).then(success, error);
```

It is expected to execute error asynchronously, but it actually try to call it synchronously after setting `reject` to `null` and fail with

```
Warning: .then() only accepts functions but was passed: [object Null], [object Null]
    at Query.then ([path]\node_modules\mongoose\node_modules\mquery\lib\mquery.js:2354:18)
...
Unhandled rejection CastError: Cast to number failed for value "1a" at path "numericProperty"
    at SchemaNumber.cast ([path]\node_modules\mongoose\lib\schema\number.js:217:9)
```