### PR TITLE
`.exec` return promise when no callback

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -2344,7 +2344,19 @@ Query.prototype.exec = function exec (op, callback) {
     callback || (callback = true);
   }
 
-  this[this.op](callback);
+  var self = this;
+
+  if ('function' == typeof callback) {
+    this[this.op](callback);
+  } else {
+    return new Query.Promise(function(success, error) {
+      self[self.op](function(err, val) {
+        if (err) error(err);
+        else success(val);
+        self = success = error = null;
+      });
+    });
+  }
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -1958,7 +1958,7 @@ describe('mquery', function(){
           m._collection.update = function (conds, doc, opts, cb) {
             m._collection.update = update;
 
-            assert.ok(!opts.safe);
+            assert.ok(opts.safe);
             assert.ok(true === opts.multi);
             assert.equal('forced', doc.$set.name);
             done();


### PR DESCRIPTION
so, wo can use like this:

```
mquery(collection)
  .find({name: 'xxx'})
  .exec()
  .then(function (res) {
    console.log(res);
  });
```

or

```
var res = yield mquery(collection).find({name: 'xxx'}).exec();
```