### PR TITLE
Ensure conds is an object before assigning attribtues

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -546,7 +546,7 @@ Query.prototype.and = function and (array) {
       path = arguments[0];
     }
 
-    var conds = typeof(this._conditions[path]) === 'object' ?
+    var conds = this._conditions[path] === null || typeof this._conditions[path] === 'object' ?
       this._conditions[path] : 
       (this._conditions[path] = {});
     conds['$' + $conditional] = val;

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -546,7 +546,9 @@ Query.prototype.and = function and (array) {
       path = arguments[0];
     }
 
-    var conds = this._conditions[path] || (this._conditions[path] = {});
+    var conds = typeof(this._conditions[path]) === 'object' ?
+      this._conditions[path] : 
+      (this._conditions[path] = {});
     conds['$' + $conditional] = val;
     return this;
   };


### PR DESCRIPTION
This is a fix for the following error:

`TypeError: Cannot assign to read only property '$ne' of true
    at Query.(anonymous function) [as ne] (node_modules/mongoose/node_modules/mquery/lib/mquery.js:522:31)`

You can reproduce this by calling Query.where(a, true) followed by Query.ne(a, false). 
The problem is that the Query.where() function evaluates conds to true, then Query.ne() later tries to assign conds.$ne = false, which is impossible because conds is a Boolean instead of an object.