### PR TITLE
feat: allow array in select

### DIFF
--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1111,7 +1111,7 @@ Query.prototype.select = function select () {
   var type = typeof arg;
 
   if (('string' == type || utils.isArgumentsObject(arg)) &&
-    'number' == typeof arg.length) {
+    'number' == typeof arg.length || Array.isArray(arg)) {
     if ('string' == type)
       arg = arg.split(/\s+/);
 
@@ -1126,7 +1126,7 @@ Query.prototype.select = function select () {
     return this;
   }
 
-  if (utils.isObject(arg) && !Array.isArray(arg)) {
+  if (utils.isObject(arg)) {
     var keys = utils.keys(arg);
     for (var i = 0; i < keys.length; ++i) {
       fields[keys[i]] = arg[keys[i]];

--- a/test/index.js
+++ b/test/index.js
@@ -927,12 +927,10 @@ describe('mquery', function(){
       assert.deepEqual(m._fields, { x: 1, y: 0 });
     })
 
-    it('does not accept an array', function(done){
-      assert.throws(function () {
-        var o = ['x', '-y'];
-        var m = mquery().select(o);
-      }, /Invalid select/);
-      done();
+    it('does accept an array', function(){
+      var o = ['x', '-y'];
+      var m = mquery().select(o);
+      assert.deepEqual(m._fields, { x: 1, y: 0 });
     })
 
     it('merges previous arguments', function(){


### PR DESCRIPTION
I think it makes sense to allow an array of keys to the `select` method.

I explain my use case:

1) case is where I have a method which will do a query at some point, and this method allows some options. One of those is an array of fields
```js
function getCats(options = {}) {
  const qry = CatModel.find();
  if (options.fields) qry.select(fields);
  return qry.exec();
}
```

this is more convenient than passing an object with 0/1 in this scenario.

2) When using lodash `_.pick()` or `_.get()` or even from immutablejs `Immutable.getIn()` you can pass an array of keys, and many times in the code you have like a defined set of keys to use here and there to pick or find common object paths.
If `.select()` would allow an array of keys, you could just re-use this list of keys directly.

please consider such an option, and if there is a strong opinion on why is not supported please share.
