### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#mquery
+# mquery
 
 `mquery` is a fluent mongodb query builder designed to run in multiple environments. As of v0.1, `mquery` runs on `Node.js` only with support for the MongoDB shell and browser environments planned for upcoming releases.
 
-##Features
+## Features
 
   - fluent query builder api
   - custom base query support
@@ -15,7 +15,7 @@
 
 [![Build Status](https://travis-ci.org/aheckmann/mquery.png)](https://travis-ci.org/aheckmann/mquery)
 
-##Use
+## Use
 
 ```js
 require('mongodb').connect(uri, function (err, db) {
@@ -39,7 +39,7 @@ require('mongodb').connect(uri, function (err, db) {
 `mquery` requires a collection object to work with. In the example above we just pass the collection object created using the official [MongoDB driver](https://github.com/mongodb/node-mongodb-native).
 
 
-##Fluent API
+## Fluent API
 
 - [find](#find)
 - [findOne](#findOne)
@@ -108,7 +108,7 @@ require('mongodb').connect(uri, function (err, db) {
 - [mquery.canMerge](#mquerycanmerge)
 - [mquery.use$geoWithin](#mqueryusegeowithin)
 
-###find()
+### find()
 
 Declares this query a _find_ query. Optionally pass a match clause and / or callback. If a callback is passed the query is executed.
 
@@ -121,7 +121,7 @@ mquery().find(match, function (err, docs) {
 })
 ```
 
-###findOne()
+### findOne()
 
 Declares this query a _findOne_ query. Optionally pass a match clause and / or callback. If a callback is passed the query is executed.
 
@@ -137,7 +137,7 @@ mquery().findOne(match, function (err, doc) {
 })
 ```
 
-###count()
+### count()
 
 Declares this query a _count_ query. Optionally pass a match clause and / or callback. If a callback is passed the query is executed.
 
@@ -150,7 +150,7 @@ mquery().count(match, function (err, number){
 })
 ```
 
-###remove()
+### remove()
 
 Declares this query a _remove_ query. Optionally pass a match clause and / or callback. If a callback is passed the query is executed.
 
@@ -161,7 +161,7 @@ mquery().remove(callback)
 mquery().remove(match, function (err){})
 ```
 
-###update()
+### update()
 
 Declares this query an _update_ query. Optionally pass an update document, match clause, options or callback. If a callback is passed, the query is executed. To force execution without passing a callback, run `update(true)`.
 
@@ -178,7 +178,7 @@ mquery().update(match, updateDocument, options, function (err, result){})
 mquery().update(true) // executes (unsafe write)
 ```
 
-#####the update document
+##### the update document
 
 All paths passed that are not `$atomic` operations will become `$set` ops. For example:
 
@@ -194,7 +194,7 @@ collection.update({ _id: id }, { $set: { title: 'words' }}, callback)
 
 This behavior can be overridden using the `overwrite` option (see below).
 
-#####options
+##### options
 
 Options are passed to the `setOptions()` method.
 
@@ -248,13 +248,13 @@ q.update(function (err, result) {
 });
 ```
 
-###findOneAndUpdate()
+### findOneAndUpdate()
 
 Declares this query a _findAndModify_ with update query. Optionally pass a match clause, update document, options, or callback. If a callback is passed, the query is executed.
 
 When executed, the first matching document (if found) is modified according to the update document and passed back to the callback.
 
-#####options
+##### options
 
 Options are passed to the `setOptions()` method.
 
@@ -308,7 +308,7 @@ A.where().findOneAndRemove(match, options, function (err, doc) {
 })
  ```
 
-###distinct()
+### distinct()
 
 Declares this query a _distinct_ query. Optionally pass the distinct field, a match clause or callback. If a callback is passed the query is executed.
 
@@ -327,7 +327,7 @@ mquery().distinct(match, field, function (err, result) {
 })
 ```
 
-###exec()
+### exec()
 
 Executes the query.
 
@@ -335,7 +335,7 @@ Executes the query.
 mquery().findOne().where('route').intersects(polygon).exec(function (err, docs){})
 ```
 
-###stream()
+### stream()
 
 Executes the query and returns a stream.
 
@@ -351,7 +351,7 @@ Note: returns the stream object directly from the node-mongodb-native driver. (c
 
 -------------
 
-###all()
+### all()
 
 Specifies an `$all` query condition
 
@@ -361,7 +361,7 @@ mquery().where('permission').all(['read', 'write'])
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/all/)
 
-###and()
+### and()
 
 Specifies arguments for an `$and` condition
 
@@ -371,7 +371,7 @@ mquery().and([{ color: 'green' }, { status: 'ok' }])
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/and/)
 
-###box()
+### box()
 
 Specifies a `$box` condition
 
@@ -384,7 +384,7 @@ mquery().where('location').within().box(lowerLeft, upperRight)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/box/)
 
-###circle()
+### circle()
 
 Specifies a `$center` or `$centerSphere` condition.
 
@@ -402,7 +402,7 @@ query.circle('loc', area);
 - [MongoDB Documentation - center](http://docs.mongodb.org/manual/reference/operator/center/)
 - [MongoDB Documentation - centerSphere](http://docs.mongodb.org/manual/reference/operator/centerSphere/)
 
-###elemMatch()
+### elemMatch()
 
 Specifies an `$elemMatch` condition
 
@@ -417,7 +417,7 @@ query.elemMatch('comment', function (elem) {
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/elemMatch/)
 
-###equals()
+### equals()
 
 Specifies the complementary comparison value for the path specified with `where()`.
 
@@ -429,7 +429,7 @@ mquery().where('age').equals(49);
 mquery().where({ 'age': 49 });
 ```
 
-###exists()
+### exists()
 
 Specifies an `$exists` condition
 
@@ -446,7 +446,7 @@ mquery().exists('name', false);
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/exists/)
 
-###geometry()
+### geometry()
 
 Specifies a `$geometry` condition
 
@@ -478,7 +478,7 @@ The `object` argument must contain `type` and `coordinates` properties.
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/geometry/)
 
-###gt()
+### gt()
 
 Specifies a `$gt` query condition.
 
@@ -488,7 +488,7 @@ mquery().where('clicks').gt(999)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/gt/)
 
-###gte()
+### gte()
 
 Specifies a `$gte` query condition.
 
@@ -498,7 +498,7 @@ Specifies a `$gte` query condition.
 mquery().where('clicks').gte(1000)
 ```
 
-###in()
+### in()
 
 Specifies an `$in` query condition.
 
@@ -508,7 +508,7 @@ mquery().where('author_id').in([3, 48901, 761])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/in/)
 
-###intersects()
+### intersects()
 
 Declares an `$geoIntersects` query for `geometry()`.
 
@@ -529,7 +529,7 @@ query.where('path').intersects({
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/geoIntersects/)
 
-###lt()
+### lt()
 
 Specifies a `$lt` query condition.
 
@@ -539,7 +539,7 @@ mquery().where('clicks').lt(50)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/lt/)
 
-###lte()
+### lte()
 
 Specifies a `$lte` query condition.
 
@@ -549,7 +549,7 @@ mquery().where('clicks').lte(49)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/lte/)
 
-###maxDistance()
+### maxDistance()
 
 Specifies a `$maxDistance` query condition.
 
@@ -559,7 +559,7 @@ mquery().where('location').near({ center: [139, 74.3] }).maxDistance(5)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/maxDistance/)
 
-###mod()
+### mod()
 
 Specifies a `$mod` condition
 
@@ -569,7 +569,7 @@ mquery().where('count').mod(2, 0)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/mod/)
 
-###ne()
+### ne()
 
 Specifies a `$ne` query condition.
 
@@ -579,7 +579,7 @@ mquery().where('status').ne('ok')
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/ne/)
 
-###nin()
+### nin()
 
 Specifies an `$nin` query condition.
 
@@ -589,7 +589,7 @@ mquery().where('author_id').nin([3, 48901, 761])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/nin/)
 
-###nor()
+### nor()
 
 Specifies arguments for an `$nor` condition.
 
@@ -599,13 +599,13 @@ mquery().nor([{ color: 'green' }, { status: 'ok' }])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/nor/)
 
-###near()
+### near()
 
 Specifies arguments for a `$near` or `$nearSphere` condition.
 
 These operators return documents sorted by distance.
 
-####Example
+#### Example
 
 ```js
 query.where('loc').near({ center: [10, 10] });
@@ -623,7 +623,7 @@ query.near({ center: [10, 10], maxDistance: 5, spherical: true });
 
 [MongoDB Documentation](http://www.mongodb.org/display/DOCS/Geospatial+Indexing)
 
-###or()
+### or()
 
 Specifies arguments for an `$or` condition.
 
@@ -633,7 +633,7 @@ mquery().or([{ color: 'red' }, { status: 'emergency' }])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/or/)
 
-###polygon()
+### polygon()
 
 Specifies a `$polygon` condition
 
@@ -644,7 +644,7 @@ mquery().polygon('loc', [10,20], [13, 25], [7,15])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/polygon/)
 
-###regex()
+### regex()
 
 Specifies a `$regex` query condition.
 
@@ -654,7 +654,7 @@ mquery().where('name').regex(/^sixstepsrecords/)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/regex/)
 
-###select()
+### select()
 
 Specifies which document fields to include or exclude
 
@@ -667,7 +667,7 @@ mquery().select({ name: 1, address: 1, _id: 0 })
 mquery().select('name address -_id')
 ```
 
-#####String syntax
+##### String syntax
 
 When passing a string, prefixing a path with `-` will flag that path as excluded. When a path does not have the `-` prefix, it is included.
 
@@ -682,7 +682,7 @@ query.select({a: 1, b: 1, c: 0});
 
 _Cannot be used with `distinct()`._
 
-###selected()
+### selected()
 
 Determines if the query has selected any fields.
 
@@ -693,7 +693,7 @@ query.select('-name');
 query.selected() // true
 ```
 
-###selectedInclusively()
+### selectedInclusively()
 
 Determines if the query has selected any fields inclusively.
 
@@ -708,7 +708,7 @@ query.selectedInclusively() // false
 query.selectedExclusively() // true
 ```
 
-###selectedExclusively()
+### selectedExclusively()
 
 Determines if the query has selected any fields exclusively.
 
@@ -723,7 +723,7 @@ query.selectedExclusively() // false
 query.selectedInclusively() // true
 ```
 
-###size()
+### size()
 
 Specifies a `$size` query condition.
 
@@ -733,7 +733,7 @@ mquery().where('someArray').size(6)
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/size/)
 
-###slice()
+### slice()
 
 Specifies a `$slice` projection for a `path`
 
@@ -745,7 +745,7 @@ mquery().where('comments').slice([-10, 5])
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/projection/slice/)
 
-###within()
+### within()
 
 Sets a `$geoWithin` or `$within` argument for geo-spatial queries.
 
@@ -769,7 +769,7 @@ As of mquery 2.0, `$geoWithin` is used by default. This impacts you if running M
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/reference/operator/geoWithin/)
 
-###where()
+### where()
 
 Specifies a `path` for use with chaining
 
@@ -791,7 +791,7 @@ mquery()
 .exec(callback)
 ```
 
-###$where()
+### $where()
 
 Specifies a `$where` condition.
 
@@ -809,7 +809,7 @@ Only use `$where` when you have a condition that cannot be met using other Mongo
 
 -----------
 
-###batchSize()
+### batchSize()
 
 Specifies the batchSize option.
 
@@ -821,7 +821,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.batchSize/)
 
-###comment()
+### comment()
 
 Specifies the comment option.
 
@@ -833,7 +833,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/)
 
-###hint()
+### hint()
 
 Sets query hints.
 
@@ -845,7 +845,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/hint/)
 
-###limit()
+### limit()
 
 Specifies the limit option.
 
@@ -857,7 +857,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.limit/)
 
-###maxScan()
+### maxScan()
 
 Specifies the maxScan option.
 
@@ -869,7 +869,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/maxScan/)
 
-###maxTime()
+### maxTime()
 
 Specifies the maxTimeMS option.
 
@@ -880,7 +880,7 @@ query.maxTime(100)
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.maxTimeMS/)
 
 
-###skip()
+### skip()
 
 Specifies the skip option.
 
@@ -892,7 +892,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.skip/)
 
-###sort()
+### sort()
 
 Sets the query sort order.
 
@@ -910,7 +910,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/cursor.sort/)
 
-###read()
+### read()
 
 Sets the readPreference option for the query.
 
@@ -931,7 +931,7 @@ mquery().read('nearest')
 mquery().read('n')  // same as nearest
 ```
 
-#####Preferences:
+##### Preferences:
 
 - `primary` - (default) Read from primary only. Operations will produce an error if primary is unavailable. Cannot be combined with tags.
 - `secondary` - Read from secondary if available, otherwise error.
@@ -947,7 +947,7 @@ Aliases
 - `sp`  secondaryPreferred
 - `n`   nearest
 
-#####Preference Tags:
+##### Preference Tags:
 
 To keep the separation of concerns between `mquery` and your driver
 clean, `mquery#read()` no longer handles specifying a second `tags` argument as of version 0.5.
@@ -964,7 +964,7 @@ mquery(..).read(preference).exec();
 
 Read more about how to use read preferences [here](http://docs.mongodb.org/manual/applications/replication/#read-preference) and [here](http://mongodb.github.com/node-mongodb-native/driver-articles/anintroductionto1_1and2_2.html#read-preferences).
 
-###slaveOk()
+### slaveOk()
 
 Sets the slaveOk option. `true` allows reading from secondaries.
 
@@ -978,7 +978,7 @@ query.slaveOk(false)
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/method/rs.slaveOk/)
 
-###snapshot()
+### snapshot()
 
 Specifies this query as a snapshot query.
 
@@ -992,7 +992,7 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/snapshot/)
 
-###tailable()
+### tailable()
 
 Sets tailable option.
 
@@ -1006,9 +1006,9 @@ _Cannot be used with `distinct()`._
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/tutorial/create-tailable-cursor/)
 
-##Helpers
+## Helpers
 
-###collection()
+### collection()
 
 Sets the querys collection.
 
@@ -1016,7 +1016,7 @@ Sets the querys collection.
 mquery().collection(aCollection)
 ```
 
-###then()
+### then()
 
 Executes the query and returns a promise which will be resolved with the query results or rejected if the query responds with an error.
 
@@ -1038,7 +1038,7 @@ The returned promise is a [bluebird](https://github.com/petkaantonov/bluebird/) 
 use your favorite promise library, simply set `mquery.Promise = YourPromiseConstructor`.
 Your `Promise` must be [promises A+](http://promisesaplus.com/) compliant.
 
-###thunk()
+### thunk()
 
 Returns a thunk which when called runs the query's `exec` method passing the results to the callback.
 
@@ -1050,7 +1050,7 @@ thunk(function(err, results) {
 })
 ```
 
-###merge(object)
+### merge(object)
 
 Merges other mquery or match condition objects into this one. When an muery instance is passed, its match conditions, field selection and options are merged.
 
@@ -1064,7 +1064,7 @@ redDrum.count(function (err, n) {
 
 Internally uses `mquery.canMerge` to determine validity.
 
-###setOptions(options)
+### setOptions(options)
 
 Sets query options.
 
@@ -1072,7 +1072,7 @@ Sets query options.
 mquery().setOptions({ collection: coll, limit: 20 })
 ```
 
-#####options
+##### options
 
 - [tailable](#tailable) *
 - [sort](#sort) *
@@ -1090,7 +1090,7 @@ mquery().setOptions({ collection: coll, limit: 20 })
 
 _* denotes a query helper method is also available_
 
-###setTraceFunction(func)
+### setTraceFunction(func)
 
 Set a function to trace this query. Useful for profiling or logging.
 
@@ -1122,7 +1122,7 @@ The trace function should return a callback function which accepts:
 
 NOTE: stream requests are not traced.
 
-###mquery.setGlobalTraceFunction(func)
+### mquery.setGlobalTraceFunction(func)
 
 Similar to `setTraceFunction()` but automatically applied to all queries.
 
@@ -1130,7 +1130,7 @@ Similar to `setTraceFunction()` but automatically applied to all queries.
 mquery.setTraceFunction(traceFunction);
 ```
 
-###mquery.canMerge(conditions)
+### mquery.canMerge(conditions)
 
 Determines if `conditions` can be merged using `mquery().merge()`.
 
@@ -1142,7 +1142,7 @@ if (okToMerge) {
 }
 ```
 
-##mquery.use$geoWithin
+## mquery.use$geoWithin
 
 MongoDB 2.4 introduced the `$geoWithin` operator which replaces and is 100% backward compatible with `$within`. As of mquery 0.2, we default to using `$geoWithin` for all `within()` calls.
 
@@ -1152,7 +1152,7 @@ If you are running MongoDB < 2.4 this will be problematic. To force `mquery` to 
 mquery.use$geoWithin = false;
 ```
 
-##Custom Base Queries
+## Custom Base Queries
 
 Often times we want custom base queries that encapsulate predefined criteria. With `mquery` this is easy. First create the query you want to reuse and call its `toConstructor()` method which returns a new subclass of `mquery` that retains all options and criteria of the original.
 
@@ -1169,11 +1169,11 @@ greatMovies().where({ name: /^Life/ }).select('name').find(function (err, docs) 
 });
 ```
 
-##Validation
+## Validation
 
 Method and options combinations are checked for validity at runtime to prevent creation of invalid query constructs. For example, a `distinct` query does not support specifying options like `hint` or field selection. In this case an error will be thrown so you can catch these mistakes in development.
 
-##Debug support
+## Debug support
 
 Debug mode is provided through the use of the [debug](https://github.com/visionmedia/debug) module. To enable:
 
@@ -1204,7 +1204,7 @@ The Read Preferences spec also support specifying tags. To pass tags, some
 drivers (Node.js driver) require passing a special constructor that handles both the read preference and its tags.
 If you need to specify tags, pass an instance of your drivers ReadPreference constructor or roll your own. `mquery` will store whatever you provide and pass later to your collection during execution.
 
-##Future goals
+## Future goals
 
   - mongo shell compatibility
   - browser compatibility


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
