### PR TITLE
Update debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
-    "debug": "^2.6.8",
+    "debug": "^2.6.9",
     "regexp-clone": "^0.0.1",
     "sliced": "0.0.5"
   },


### PR DESCRIPTION
> See https://nodesecurity.io/advisories/534

Actually, I think de8c929d48133b1e17e928a44672c3105527d813 fixes this already -- better to be sure.

Please release ASAP.
Then, we'll need to update `mquery`'s version in `mongoose`.
That's the thing about fixed dependencies. There are pros and cons :-)

Thank you!