### PR TITLE
3.0: remove retainKeyOrder, drop support for old node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
+  - "7"
+  - "8"
+  - "9"
 services:
   - mongodb

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -36,15 +36,15 @@ function Query (criteria, options) {
   this.setOptions(proto.options);
 
   this._conditions = proto._conditions
-    ? utils.clone(proto._conditions, { retainKeyOrder: this.options.retainKeyOrder })
+    ? utils.clone(proto._conditions)
     : {};
 
   this._fields = proto._fields
-    ? utils.clone(proto._fields, { retainKeyOrder: this.options.retainKeyOrder })
+    ? utils.clone(proto._fields)
     : undefined;
 
   this._update = proto._update
-    ? utils.clone(proto._update, { retainKeyOrder: this.options.retainKeyOrder })
+    ? utils.clone(proto._update)
     : undefined;
 
   this._path = proto._path || undefined;
@@ -130,9 +130,9 @@ Query.prototype.toConstructor = function toConstructor () {
   p.setOptions(this.options);
 
   p.op = this.op;
-  p._conditions = utils.clone(this._conditions, { retainKeyOrder: this.options.retainKeyOrder });
-  p._fields = utils.clone(this._fields, { retainKeyOrder: this.options.retainKeyOrder });
-  p._update = utils.clone(this._update, { retainKeyOrder: this.options.retainKeyOrder });
+  p._conditions = utils.clone(this._conditions);
+  p._fields = utils.clone(this._fields);
+  p._update = utils.clone(this._update);
   p._path = this._path;
   p._distinct = this._distinct;
   p._collection = this._collection;
@@ -2894,7 +2894,7 @@ Query.prototype._mergeUpdate = function (doc) {
  */
 
 Query.prototype._optionsForExec = function () {
-  var options = utils.clone(this.options, { retainKeyOrder: true });
+  var options = utils.clone(this.options);
   return options;
 }
 
@@ -2906,7 +2906,7 @@ Query.prototype._optionsForExec = function () {
  */
 
 Query.prototype._fieldsForExec = function () {
-  return utils.clone(this._fields, { retainKeyOrder: true });
+  return utils.clone(this._fields);
 }
 
 /**
@@ -2916,7 +2916,7 @@ Query.prototype._fieldsForExec = function () {
  */
 
 Query.prototype._updateForExec = function () {
-  var update = utils.clone(this._update, { retainKeyOrder: true })
+  var update = utils.clone(this._update)
     , ops = utils.keys(update)
     , i = ops.length
     , ret = {}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,38 +63,20 @@ var clone = exports.clone = function clone (obj, options) {
  */
 
 var cloneObject = exports.cloneObject = function cloneObject (obj, options) {
-  var retainKeyOrder = options && options.retainKeyOrder
-    , minimize = options && options.minimize
-    , ret = {}
-    , hasKeys
-    , keys
-    , val
-    , k
-    , i
+  var minimize = options && options.minimize;
+  var ret = {};
+  var hasKeys;
+  var keys;
+  var val;
+  var k;
+  var i;
 
-  if (retainKeyOrder) {
-    for (k in obj) {
-      val = clone(obj[k], options);
+  for (k in obj) {
+    val = clone(obj[k], options);
 
-      if (!minimize || ('undefined' !== typeof val)) {
-        hasKeys || (hasKeys = true);
-        ret[k] = val;
-      }
-    }
-  } else {
-    // faster
-
-    keys = Object.keys(obj);
-    i = keys.length;
-
-    while (i--) {
-      k = keys[i];
-      val = clone(obj[k], options);
-
-      if (!minimize || ('undefined' !== typeof val)) {
-        if (!hasKeys) hasKeys = true;
-        ret[k] = val;
-      }
+    if (!minimize || ('undefined' !== typeof val)) {
+      hasKeys || (hasKeys = true);
+      ret[k] = val;
     }
   }
 
@@ -182,16 +164,12 @@ var mergeClone = exports.mergeClone = function mergeClone (to, from) {
   while (i--) {
     key = keys[i];
     if ('undefined' === typeof to[key]) {
-      // make sure to retain key order here because of a bug handling the $each
-      // operator in mongodb 2.4.4
-      to[key] = clone(from[key], { retainKeyOrder : 1});
+      to[key] = clone(from[key]);
     } else {
       if (exports.isObject(from[key])) {
         mergeClone(to[key], from[key]);
       } else {
-        // make sure to retain key order here because of a bug handling the
-        // $each operator in mongodb 2.4.4
-        to[key] = clone(from[key], { retainKeyOrder : 1});
+        to[key] = clone(from[key]);
       }
     }
   }


### PR DESCRIPTION
As much as I'll miss making jokes about this scene from The Empire Strikes Back:

![image](https://user-images.githubusercontent.com/1620265/33689213-765f0df2-da93-11e7-812c-8a1fbdbc5bd7.png)

Time has shown that `retainKeyOrder` was not a good idea and needs to go. Re Automattic/mongoose#2749