### PR TITLE
add eslint, update coding styles and deps. fix some bugs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,9 @@ node_js:
   - "7"
   - "8"
   - "9"
+  - "10"
+script:
+  - npm test
+  - npm run lint
 services:
   - mongodb

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,16 @@ test-cov:
 open-cov:
 	open coverage/lcov-report/index.html
 
+lint:
+	@NODE_ENV=test node ./node_modules/eslint/bin/eslint.js .
+
 test-travis:
 	@NODE_ENV=test node \
 		node_modules/.bin/istanbul cover \
 		./node_modules/.bin/_mocha \
 		--report lcovonly \
-		-- -u exports \
 		--bail
+	@NODE_ENV=test node \
+		./node_modules/eslint/bin/eslint.js .
 
-.PHONY: test test-cov open-cov test-travis
+.PHONY: test test-cov open-cov lint test-travis

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 `mquery` is a fluent mongodb query builder designed to run in multiple environments.
 
+[![Build Status](https://travis-ci.org/aheckmann/mquery.svg?branch=master)](https://travis-ci.org/aheckmann/mquery)
+[![NPM version](https://badge.fury.io/js/mquery.svg)](http://badge.fury.io/js/mquery)
+
+[![npm](https://nodei.co/npm/mquery.png)](https://www.npmjs.com/package/mquery)
+
 ## Features
 
   - fluent query builder api
@@ -12,8 +17,6 @@
   - environment detection
   - [debug](https://github.com/visionmedia/debug) support
   - separated collection implementations for maximum flexibility
-
-[![Build Status](https://travis-ci.org/aheckmann/mquery.png)](https://travis-ci.org/aheckmann/mquery)
 
 ## Use
 
@@ -89,8 +92,7 @@ require('mongodb').connect(uri, function (err, db) {
 - [hint](#hint)
 - [limit](#limit)
 - [maxScan](#maxscan)
-- [maxTime](#maxtime)
-- [maxTimeMS](#maxtime)
+- [maxTime, maxTimeMS](#maxtime)
 - [skip](#skip)
 - [sort](#sort)
 - [read](#read)

--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -5,27 +5,27 @@
  */
 
 var methods = [
-    'find'
-  , 'findOne'
-  , 'update'
-  , 'updateMany',
-  , 'updateOne'
-  , 'replaceOne'
-  , 'remove'
-  , 'count'
-  , 'distinct'
-  , 'findAndModify'
-  , 'aggregate'
-  , 'findStream'
-  , 'deleteOne'
-  , 'deleteMany'
+  'find',
+  'findOne',
+  'update',
+  'updateMany',
+  'updateOne',
+  'replaceOne',
+  'remove',
+  'count',
+  'distinct',
+  'findAndModify',
+  'aggregate',
+  'findStream',
+  'deleteOne',
+  'deleteMany'
 ];
 
 /**
  * Collection base class from which implementations inherit
  */
 
-function Collection () {}
+function Collection() {}
 
 for (var i = 0, len = methods.length; i < len; ++i) {
   var method = methods[i];
@@ -39,8 +39,8 @@ Collection.methods = methods;
  * creates a function which throws an implementation error
  */
 
-function notImplemented (method) {
-  return function () {
+function notImplemented(method) {
+  return function() {
     throw new Error('collection.' + method + ' not implemented');
-  }
+  };
 }

--- a/lib/collection/index.js
+++ b/lib/collection/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var env = require('../env')
+var env = require('../env');
 
 if ('unknown' == env.type) {
-  throw new Error('Unknown environment')
+  throw new Error('Unknown environment');
 }
 
 module.exports =
   env.isNode ? require('./node') :
-  env.isMongo ? require('./collection') :
-  require('./collection');
+    env.isMongo ? require('./collection') :
+      require('./collection');
 

--- a/lib/collection/node.js
+++ b/lib/collection/node.js
@@ -7,7 +7,7 @@
 var Collection = require('./collection');
 var utils = require('../utils');
 
-function NodeCollection (col) {
+function NodeCollection(col) {
   this.collection = col;
   this.collectionName = col.collectionName;
 }
@@ -22,8 +22,8 @@ utils.inherits(NodeCollection, Collection);
  * find(match, options, function(err, docs))
  */
 
-NodeCollection.prototype.find = function (match, options, cb) {
-  this.collection.find(match, options, function (err, cursor) {
+NodeCollection.prototype.find = function(match, options, cb) {
+  this.collection.find(match, options, function(err, cursor) {
     if (err) return cb(err);
 
     try {
@@ -32,104 +32,104 @@ NodeCollection.prototype.find = function (match, options, cb) {
       cb(error);
     }
   });
-}
+};
 
 /**
  * findOne(match, options, function(err, doc))
  */
 
-NodeCollection.prototype.findOne = function (match, options, cb) {
+NodeCollection.prototype.findOne = function(match, options, cb) {
   this.collection.findOne(match, options, cb);
-}
+};
 
 /**
  * count(match, options, function(err, count))
  */
 
-NodeCollection.prototype.count = function (match, options, cb) {
+NodeCollection.prototype.count = function(match, options, cb) {
   this.collection.count(match, options, cb);
-}
+};
 
 /**
  * distinct(prop, match, options, function(err, count))
  */
 
-NodeCollection.prototype.distinct  = function (prop, match, options, cb) {
+NodeCollection.prototype.distinct = function(prop, match, options, cb) {
   this.collection.distinct(prop, match, options, cb);
-}
+};
 
 /**
  * update(match, update, options, function(err[, result]))
  */
 
-NodeCollection.prototype.update = function (match, update, options, cb) {
+NodeCollection.prototype.update = function(match, update, options, cb) {
   this.collection.update(match, update, options, cb);
-}
+};
 
 /**
  * update(match, update, options, function(err[, result]))
  */
 
-NodeCollection.prototype.updateMany = function (match, update, options, cb) {
+NodeCollection.prototype.updateMany = function(match, update, options, cb) {
   this.collection.updateMany(match, update, options, cb);
-}
+};
 
 /**
  * update(match, update, options, function(err[, result]))
  */
 
-NodeCollection.prototype.updateOne = function (match, update, options, cb) {
+NodeCollection.prototype.updateOne = function(match, update, options, cb) {
   this.collection.updateOne(match, update, options, cb);
-}
+};
 
 /**
  * replaceOne(match, update, options, function(err[, result]))
  */
 
-NodeCollection.prototype.replaceOne = function (match, update, options, cb) {
+NodeCollection.prototype.replaceOne = function(match, update, options, cb) {
   this.collection.replaceOne(match, update, options, cb);
-}
+};
 
 /**
  * deleteOne(match, options, function(err[, result])
  */
 
-NodeCollection.prototype.deleteOne = function (match, options, cb) {
+NodeCollection.prototype.deleteOne = function(match, options, cb) {
   this.collection.deleteOne(match, options, cb);
-}
+};
 
 /**
  * deleteMany(match, options, function(err[, result])
  */
 
-NodeCollection.prototype.deleteMany = function (match, options, cb) {
+NodeCollection.prototype.deleteMany = function(match, options, cb) {
   this.collection.deleteMany(match, options, cb);
-}
+};
 
 /**
  * remove(match, options, function(err[, result])
  */
 
-NodeCollection.prototype.remove = function (match, options, cb) {
+NodeCollection.prototype.remove = function(match, options, cb) {
   this.collection.remove(match, options, cb);
-}
+};
 
 /**
  * findAndModify(match, update, options, function(err, doc))
  */
 
-NodeCollection.prototype.findAndModify = function (match, update, options, cb) {
+NodeCollection.prototype.findAndModify = function(match, update, options, cb) {
   var sort = Array.isArray(options.sort) ? options.sort : [];
   this.collection.findAndModify(match, sort, update, options, cb);
-}
+};
 
 /**
  * var stream = findStream(match, findOptions, streamOptions)
  */
 
 NodeCollection.prototype.findStream = function(match, findOptions, streamOptions) {
-  return this.collection.find(match, findOptions);
-}
+  return this.collection.find(match, findOptions).stream(streamOptions);
+};
 
 /**
  * var cursor = findCursor(match, findOptions)
@@ -137,7 +137,7 @@ NodeCollection.prototype.findStream = function(match, findOptions, streamOptions
 
 NodeCollection.prototype.findCursor = function(match, findOptions) {
   return this.collection.find(match, findOptions);
-}
+};
 
 /**
  * aggregation(operators..., function(err, doc))

--- a/lib/env.js
+++ b/lib/env.js
@@ -4,7 +4,7 @@ exports.isNode = 'undefined' != typeof process
            && 'object' == typeof module
            && 'object' == typeof global
            && 'function' == typeof Buffer
-           && process.argv
+           && process.argv;
 
 exports.isMongo = !exports.isNode
            && 'function' == typeof printjson
@@ -18,5 +18,5 @@ exports.isBrowser = !exports.isNode
 
 exports.type = exports.isNode ? 'node'
   : exports.isMongo ? 'mongo'
-  : exports.isBrowser ? 'browser'
-  : 'unknown'
+    : exports.isBrowser ? 'browser'
+      : 'unknown';

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -4,11 +4,13 @@
  * Dependencies
  */
 
-var slice = require('sliced')
-var assert = require('assert')
-var util = require('util')
-var utils = require('./utils')
+var slice = require('sliced');
+var assert = require('assert');
+var util = require('util');
+var utils = require('./utils');
 var debug = require('debug')('mquery');
+
+/* global Map */
 
 /**
  * Query constructor used for building queries.
@@ -24,7 +26,7 @@ var debug = require('debug')('mquery');
  * @api public
  */
 
-function Query (criteria, options) {
+function Query(criteria, options) {
   if (!(this instanceof Query))
     return new Query(criteria, options);
 
@@ -78,15 +80,15 @@ function Query (criteria, options) {
 
 var $withinCmd = '$geoWithin';
 Object.defineProperty(Query, 'use$geoWithin', {
-    get: function ( ) { return $withinCmd == '$geoWithin' }
-  , set: function (v) {
-      if (true === v) {
-        // mongodb >= 2.4
-        $withinCmd = '$geoWithin';
-      } else {
-        $withinCmd = '$within';
-      }
+  get: function( ) { return $withinCmd == '$geoWithin'; },
+  set: function(v) {
+    if (true === v) {
+      // mongodb >= 2.4
+      $withinCmd = '$geoWithin';
+    } else {
+      $withinCmd = '$within';
     }
+  }
 });
 
 /**
@@ -114,8 +116,8 @@ Object.defineProperty(Query, 'use$geoWithin', {
  * @api public
  */
 
-Query.prototype.toConstructor = function toConstructor () {
-  function CustomQuery (criteria, options) {
+Query.prototype.toConstructor = function toConstructor() {
+  function CustomQuery(criteria, options) {
     if (!(this instanceof CustomQuery))
       return new CustomQuery(criteria, options);
     Query.call(this, criteria, options);
@@ -139,7 +141,7 @@ Query.prototype.toConstructor = function toConstructor () {
   p._traceFunction = this._traceFunction;
 
   return CustomQuery;
-}
+};
 
 /**
  * Sets query options.
@@ -166,13 +168,13 @@ Query.prototype.toConstructor = function toConstructor () {
  * @api public
  */
 
-Query.prototype.setOptions = function (options) {
+Query.prototype.setOptions = function(options) {
   if (!(options && utils.isObject(options)))
     return this;
 
   // set arbitrary options
-  var methods = utils.keys(options)
-    , method
+  var methods = utils.keys(options),
+      method;
 
   for (var i = 0; i < methods.length; ++i) {
     method = methods[i];
@@ -182,14 +184,14 @@ Query.prototype.setOptions = function (options) {
       var args = utils.isArray(options[method])
         ? options[method]
         : [options[method]];
-      this[method].apply(this, args)
+      this[method].apply(this, args);
     } else {
       this.options[method] = options[method];
     }
   }
 
   return this;
-}
+};
 
 /**
  * Sets this Querys collection.
@@ -198,19 +200,19 @@ Query.prototype.setOptions = function (options) {
  * @return {Query} this
  */
 
-Query.prototype.collection = function collection (coll) {
+Query.prototype.collection = function collection(coll) {
   this._collection = new Query.Collection(coll);
 
   return this;
-}
+};
 
 /**
  * Adds a collation to this op (MongoDB 3.4 and up)
  *
  * ####Example
- * 
+ *
  *     query.find().collation({ locale: "en_US", strength: 1 })
- * 
+ *
  * @param {Object} value
  * @return {Query} this
  * @see MongoDB docs https://docs.mongodb.com/manual/reference/method/cursor.collation/#cursor.collation
@@ -242,10 +244,10 @@ Query.prototype.collation = function(value) {
  * @api public
  */
 
-Query.prototype.$where = function (js) {
+Query.prototype.$where = function(js) {
   this._conditions.$where = js;
   return this;
-}
+};
 
 /**
  * Specifies a `path` for use with chaining.
@@ -274,7 +276,7 @@ Query.prototype.$where = function (js) {
  * @api public
  */
 
-Query.prototype.where = function () {
+Query.prototype.where = function() {
   if (!arguments.length) return this;
   if (!this.op) this.op = 'find';
 
@@ -295,7 +297,7 @@ Query.prototype.where = function () {
   }
 
   throw new TypeError('path must be a string or object');
-}
+};
 
 /**
  * Specifies the complementary comparison value for paths specified with `where()`
@@ -313,12 +315,12 @@ Query.prototype.where = function () {
  * @api public
  */
 
-Query.prototype.equals = function equals (val) {
+Query.prototype.equals = function equals(val) {
   this._ensurePath('equals');
   var path = this._path;
   this._conditions[path] = val;
   return this;
-}
+};
 
 /**
  * Specifies the complementary comparison value for paths specified with `where()`
@@ -341,12 +343,12 @@ Query.prototype.equals = function equals (val) {
  * @api public
  */
 
-Query.prototype.eq = function eq (val) {
+Query.prototype.eq = function eq(val) {
   this._ensurePath('eq');
   var path = this._path;
   this._conditions[path] = val;
   return this;
-}
+};
 
 /**
  * Specifies arguments for an `$or` condition.
@@ -360,12 +362,12 @@ Query.prototype.eq = function eq (val) {
  * @api public
  */
 
-Query.prototype.or = function or (array) {
+Query.prototype.or = function or(array) {
   var or = this._conditions.$or || (this._conditions.$or = []);
   if (!utils.isArray(array)) array = [array];
   or.push.apply(or, array);
   return this;
-}
+};
 
 /**
  * Specifies arguments for a `$nor` condition.
@@ -379,12 +381,12 @@ Query.prototype.or = function or (array) {
  * @api public
  */
 
-Query.prototype.nor = function nor (array) {
+Query.prototype.nor = function nor(array) {
   var nor = this._conditions.$nor || (this._conditions.$nor = []);
   if (!utils.isArray(array)) array = [array];
   nor.push.apply(nor, array);
   return this;
-}
+};
 
 /**
  * Specifies arguments for a `$and` condition.
@@ -399,12 +401,12 @@ Query.prototype.nor = function nor (array) {
  * @api public
  */
 
-Query.prototype.and = function and (array) {
+Query.prototype.and = function and(array) {
   var and = this._conditions.$and || (this._conditions.$and = []);
   if (!Array.isArray(array)) array = [array];
   and.push.apply(and, array);
   return this;
-}
+};
 
 /**
  * Specifies a $gt query condition.
@@ -551,8 +553,8 @@ Query.prototype.and = function and (array) {
  *     Thing.where('type').nin(array)
  */
 
-'gt gte lt lte ne in nin all regex size maxDistance minDistance'.split(' ').forEach(function ($conditional) {
-  Query.prototype[$conditional] = function () {
+'gt gte lt lte ne in nin all regex size maxDistance minDistance'.split(' ').forEach(function($conditional) {
+  Query.prototype[$conditional] = function() {
     var path, val;
 
     if (1 === arguments.length) {
@@ -570,7 +572,7 @@ Query.prototype.and = function and (array) {
     conds['$' + $conditional] = val;
     return this;
   };
-})
+});
 
 /**
  * Specifies a `$mod` condition
@@ -581,15 +583,15 @@ Query.prototype.and = function and (array) {
  * @api public
  */
 
-Query.prototype.mod = function () {
+Query.prototype.mod = function() {
   var val, path;
 
   if (1 === arguments.length) {
-    this._ensurePath('mod')
+    this._ensurePath('mod');
     val = arguments[0];
     path = this._path;
   } else if (2 === arguments.length && !utils.isArray(arguments[1])) {
-    this._ensurePath('mod')
+    this._ensurePath('mod');
     val = slice(arguments);
     path = this._path;
   } else if (3 === arguments.length) {
@@ -603,7 +605,7 @@ Query.prototype.mod = function () {
   var conds = this._conditions[path] || (this._conditions[path] = {});
   conds.$mod = val;
   return this;
-}
+};
 
 /**
  * Specifies an `$exists` condition
@@ -625,7 +627,7 @@ Query.prototype.mod = function () {
  * @api public
  */
 
-Query.prototype.exists = function () {
+Query.prototype.exists = function() {
   var path, val;
 
   if (0 === arguments.length) {
@@ -649,7 +651,7 @@ Query.prototype.exists = function () {
   var conds = this._conditions[path] || (this._conditions[path] = {});
   conds.$exists = val;
   return this;
-}
+};
 
 /**
  * Specifies an `$elemMatch` condition
@@ -676,9 +678,9 @@ Query.prototype.exists = function () {
  * @api public
  */
 
-Query.prototype.elemMatch = function () {
+Query.prototype.elemMatch = function() {
   if (null == arguments[0])
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
 
   var fn, path, criteria;
 
@@ -697,7 +699,7 @@ Query.prototype.elemMatch = function () {
     path = arguments[0];
     criteria = arguments[1];
   } else {
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
   }
 
   if (fn) {
@@ -709,7 +711,7 @@ Query.prototype.elemMatch = function () {
   var conds = this._conditions[path] || (this._conditions[path] = {});
   conds.$elemMatch = criteria;
   return this;
-}
+};
 
 // Spatial queries
 
@@ -739,7 +741,7 @@ Query.prototype.elemMatch = function () {
  * @api public
  */
 
-Query.prototype.within = function within () {
+Query.prototype.within = function within() {
   // opinionated, must be used after where
   this._ensurePath('within');
   this._geoComparison = $withinCmd;
@@ -772,7 +774,7 @@ Query.prototype.within = function within () {
     return this.geometry(area);
 
   throw new TypeError('Invalid argument');
-}
+};
 
 /**
  * Specifies a $box condition
@@ -793,7 +795,7 @@ Query.prototype.within = function within () {
  * @api public
  */
 
-Query.prototype.box = function () {
+Query.prototype.box = function() {
   var path, box;
 
   if (3 === arguments.length) {
@@ -806,13 +808,13 @@ Query.prototype.box = function () {
     path = this._path;
     box = [arguments[0], arguments[1]];
   } else {
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
   }
 
   var conds = this._conditions[path] || (this._conditions[path] = {});
-  conds[this._geoComparison || $withinCmd] = { '$box': box  };
+  conds[this._geoComparison || $withinCmd] = { '$box': box };
   return this;
-}
+};
 
 /**
  * Specifies a $polygon condition
@@ -829,7 +831,7 @@ Query.prototype.box = function () {
  * @api public
  */
 
-Query.prototype.polygon = function () {
+Query.prototype.polygon = function() {
   var val, path;
 
   if ('string' == typeof arguments[0]) {
@@ -846,7 +848,7 @@ Query.prototype.polygon = function () {
   var conds = this._conditions[path] || (this._conditions[path] = {});
   conds[this._geoComparison || $withinCmd] = { '$polygon': val };
   return this;
-}
+};
 
 /**
  * Specifies a $center or $centerSphere condition.
@@ -869,7 +871,7 @@ Query.prototype.polygon = function () {
  * @api public
  */
 
-Query.prototype.circle = function () {
+Query.prototype.circle = function() {
   var path, val;
 
   if (1 === arguments.length) {
@@ -880,7 +882,7 @@ Query.prototype.circle = function () {
     path = arguments[0];
     val = arguments[1];
   } else {
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
   }
 
   if (!('radius' in val && val.center))
@@ -897,10 +899,10 @@ Query.prototype.circle = function () {
   conds[wKey][type] = [val.center, val.radius];
 
   if ('unique' in val)
-    conds[wKey].$uniqueDocs = !! val.unique;
+    conds[wKey].$uniqueDocs = !!val.unique;
 
   return this;
-}
+};
 
 /**
  * Specifies a `$near` or `$nearSphere` condition
@@ -923,7 +925,7 @@ Query.prototype.circle = function () {
  * @api public
  */
 
-Query.prototype.near = function near () {
+Query.prototype.near = function near() {
   var path, val;
 
   this._geoComparison = '$near';
@@ -938,7 +940,7 @@ Query.prototype.near = function near () {
     path = arguments[0];
     val = arguments[1];
   } else {
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
   }
 
   if (!val.center) {
@@ -968,7 +970,7 @@ Query.prototype.near = function near () {
   } else {
     // GeoJSON?
     if (val.center.type != 'Point' || !Array.isArray(val.center.coordinates)) {
-      throw new Error(util.format("Invalid GeoJSON specified for %s", type));
+      throw new Error(util.format('Invalid GeoJSON specified for %s', type));
     }
     conds[type] = { $geometry : val.center };
 
@@ -982,7 +984,7 @@ Query.prototype.near = function near () {
   }
 
   return this;
-}
+};
 
 /**
  * Declares an intersects query for `geometry()`.
@@ -1004,7 +1006,7 @@ Query.prototype.near = function near () {
  * @api public
  */
 
-Query.prototype.intersects = function intersects () {
+Query.prototype.intersects = function intersects() {
   // opinionated, must be used after where
   this._ensurePath('intersects');
 
@@ -1020,7 +1022,7 @@ Query.prototype.intersects = function intersects () {
     return this.geometry(area);
 
   throw new TypeError('Invalid argument');
-}
+};
 
 /**
  * Specifies a `$geometry` condition
@@ -1059,7 +1061,7 @@ Query.prototype.intersects = function intersects () {
  * @api public
  */
 
-Query.prototype.geometry = function geometry () {
+Query.prototype.geometry = function geometry() {
   if (!('$within' == this._geoComparison ||
         '$geoWithin' == this._geoComparison ||
         '$near' == this._geoComparison ||
@@ -1074,7 +1076,7 @@ Query.prototype.geometry = function geometry () {
     path = this._path;
     val = arguments[0];
   } else {
-    throw new TypeError("Invalid argument");
+    throw new TypeError('Invalid argument');
   }
 
   if (!(val.type && Array.isArray(val.coordinates))) {
@@ -1085,7 +1087,7 @@ Query.prototype.geometry = function geometry () {
   conds[this._geoComparison] = { $geometry: val };
 
   return this;
-}
+};
 
 // end spatial
 
@@ -1115,25 +1117,26 @@ Query.prototype.geometry = function geometry () {
  * @api public
  */
 
-Query.prototype.select = function select () {
+Query.prototype.select = function select() {
   var arg = arguments[0];
   if (!arg) return this;
 
   if (arguments.length !== 1) {
-    throw new Error("Invalid select: select only takes 1 argument");
+    throw new Error('Invalid select: select only takes 1 argument');
   }
 
   this._validate('select');
 
   var fields = this._fields || (this._fields = {});
   var type = typeof arg;
+  var i, len;
 
   if (('string' == type || utils.isArgumentsObject(arg)) &&
     'number' == typeof arg.length || Array.isArray(arg)) {
     if ('string' == type)
       arg = arg.split(/\s+/);
 
-    for (var i = 0, len = arg.length; i < len; ++i) {
+    for (i = 0, len = arg.length; i < len; ++i) {
       var field = arg[i];
       if (!field) continue;
       var include = '-' == field[0] ? 0 : 1;
@@ -1146,14 +1149,14 @@ Query.prototype.select = function select () {
 
   if (utils.isObject(arg)) {
     var keys = utils.keys(arg);
-    for (var i = 0; i < keys.length; ++i) {
+    for (i = 0; i < keys.length; ++i) {
       fields[keys[i]] = arg[keys[i]];
     }
     return this;
   }
 
   throw new TypeError('Invalid select() argument. Must be string or object.');
-}
+};
 
 /**
  * Specifies a $slice condition for a `path`
@@ -1173,7 +1176,7 @@ Query.prototype.select = function select () {
  * @api public
  */
 
-Query.prototype.slice = function () {
+Query.prototype.slice = function() {
   if (0 === arguments.length)
     return this;
 
@@ -1211,7 +1214,7 @@ Query.prototype.slice = function () {
   var myFields = this._fields || (this._fields = {});
   myFields[path] = { '$slice': val };
   return this;
-}
+};
 
 /**
  * Sets the sort order
@@ -1237,9 +1240,9 @@ Query.prototype.slice = function () {
  * @api public
  */
 
-Query.prototype.sort = function (arg) {
+Query.prototype.sort = function(arg) {
   if (!arg) return this;
-  var len;
+  var i, len, field;
 
   this._validate('sort');
 
@@ -1248,7 +1251,7 @@ Query.prototype.sort = function (arg) {
   // .sort([['field', 1], ['test', -1]])
   if (Array.isArray(arg)) {
     len = arg.length;
-    for (var i = 0; i < arg.length; ++i) {
+    for (i = 0; i < arg.length; ++i) {
       if (!Array.isArray(arg[i])) {
         throw new Error('Invalid sort() argument, must be array of arrays');
       }
@@ -1261,8 +1264,8 @@ Query.prototype.sort = function (arg) {
   if (1 === arguments.length && 'string' == type) {
     arg = arg.split(/\s+/);
     len = arg.length;
-    for (var i = 0; i < len; ++i) {
-      var field = arg[i];
+    for (i = 0; i < len; ++i) {
+      field = arg[i];
       if (!field) continue;
       var ascend = '-' == field[0] ? -1 : 1;
       if (ascend === -1) field = field.substring(1);
@@ -1275,8 +1278,8 @@ Query.prototype.sort = function (arg) {
   // .sort({ field: 1, test: -1 })
   if (utils.isObject(arg)) {
     var keys = utils.keys(arg);
-    for (var i = 0; i < keys.length; ++i) {
-      var field = keys[i];
+    for (i = 0; i < keys.length; ++i) {
+      field = keys[i];
       push(this.options, field, arg[field]);
     }
 
@@ -1287,9 +1290,8 @@ Query.prototype.sort = function (arg) {
     _pushMap(this.options, arg);
     return this;
   }
-
   throw new TypeError('Invalid sort() argument. Must be a string, object, or array.');
-}
+};
 
 /*!
  * @ignore
@@ -1302,22 +1304,23 @@ var _validSortValue = {
   'ascending': 1,
   'desc': -1,
   'descending': -1
-}
+};
 
-function push (opts, field, value) {
+function push(opts, field, value) {
   if (Array.isArray(opts.sort)) {
-    throw new TypeError("Can't mix sort syntaxes. Use either array or object:" +
-      "\n- `.sort([['field', 1], ['test', -1]])`" +
-      "\n- `.sort({ field: 1, test: -1 })`");
+    throw new TypeError('Can\'t mix sort syntaxes. Use either array or object:' +
+      '\n- `.sort([[\'field\', 1], [\'test\', -1]])`' +
+      '\n- `.sort({ field: 1, test: -1 })`');
   }
 
+  var s;
   if (value && value.$meta) {
-    var s = opts.sort || (opts.sort = {});
+    s = opts.sort || (opts.sort = {});
     s[field] = { $meta : value.$meta };
     return;
   }
 
-  var s = opts.sort || (opts.sort = {});
+  s = opts.sort || (opts.sort = {});
   var val = String(value || 1).toLowerCase();
   val = _validSortValue[val];
   if (!val) throw new TypeError('Invalid sort value: { ' + field + ': ' + value + ' }');
@@ -1325,12 +1328,12 @@ function push (opts, field, value) {
   s[field] = val;
 }
 
-function _pushArr (opts, field, value) {
+function _pushArr(opts, field, value) {
   opts.sort = opts.sort || [];
   if (!Array.isArray(opts.sort)) {
-    throw new TypeError("Can't mix sort syntaxes. Use either array or object:" +
-      "\n- `.sort([['field', 1], ['test', -1]])`" +
-      "\n- `.sort({ field: 1, test: -1 })`");
+    throw new TypeError('Can\'t mix sort syntaxes. Use either array or object:' +
+      '\n- `.sort([[\'field\', 1], [\'test\', -1]])`' +
+      '\n- `.sort({ field: 1, test: -1 })`');
   }
 
   var val = String(value || 1).toLowerCase();
@@ -1340,16 +1343,16 @@ function _pushArr (opts, field, value) {
   opts.sort.push([field, val]);
 }
 
-function _pushMap (opts, map) {
+function _pushMap(opts, map) {
   opts.sort = opts.sort || new Map();
   if (!(opts.sort instanceof Map)) {
-    throw new TypeError("Can't mix sort syntaxes. Use either array or " +
-      "object or map consistently");
+    throw new TypeError('Can\'t mix sort syntaxes. Use either array or ' +
+      'object or map consistently');
   }
   map.forEach(function(value, key) {
     var val = String(value || 1).toLowerCase();
     val = _validSortValue[val];
-    if (!val) throw new TypeError('Invalid sort value: < ' + field + ': ' + value + ' >');
+    if (!val) throw new TypeError('Invalid sort value: < ' + key + ': ' + value + ' >');
 
     opts.sort.set(key, val);
   });
@@ -1451,13 +1454,13 @@ function _pushMap (opts, map) {
  *     query.comment('feed query');
  */
 
-;['limit', 'skip', 'maxScan', 'batchSize', 'comment'].forEach(function (method) {
-  Query.prototype[method] = function (v) {
+['limit', 'skip', 'maxScan', 'batchSize', 'comment'].forEach(function(method) {
+  Query.prototype[method] = function(v) {
     this._validate(method);
     this.options[method] = v;
     return this;
   };
-})
+});
 
 /**
  * Specifies the maxTimeMS option.
@@ -1474,7 +1477,7 @@ function _pushMap (opts, map) {
  * @api public
  */
 
-Query.prototype.maxTime = Query.prototype.maxTimeMS = function (v) {
+Query.prototype.maxTime = Query.prototype.maxTimeMS = function(v) {
   this._validate('maxTime');
   this.options.maxTimeMS = v;
   return this;
@@ -1498,15 +1501,15 @@ Query.prototype.maxTime = Query.prototype.maxTimeMS = function (v) {
  * @api public
  */
 
-Query.prototype.snapshot = function () {
+Query.prototype.snapshot = function() {
   this._validate('snapshot');
 
   this.options.snapshot = arguments.length
-    ? !! arguments[0]
-    : true
+    ? !!arguments[0]
+    : true;
 
   return this;
-}
+};
 
 /**
  * Sets query hints.
@@ -1526,7 +1529,7 @@ Query.prototype.snapshot = function () {
  * @api public
  */
 
-Query.prototype.hint = function () {
+Query.prototype.hint = function() {
   if (0 === arguments.length) return this;
 
   this._validate('hint');
@@ -1548,7 +1551,7 @@ Query.prototype.hint = function () {
   }
 
   throw new TypeError('Invalid hint. ' + arg);
-}
+};
 
 /**
  * Sets the slaveOk option. _Deprecated_ in MongoDB 2.2 in favor of read preferences.
@@ -1567,10 +1570,10 @@ Query.prototype.hint = function () {
  * @api public
  */
 
-Query.prototype.slaveOk = function (v) {
+Query.prototype.slaveOk = function(v) {
   this.options.slaveOk = arguments.length ? !!v : true;
   return this;
-}
+};
 
 /**
  * Sets the readPreference option for the query.
@@ -1620,14 +1623,14 @@ Query.prototype.slaveOk = function (v) {
  * @api public
  */
 
-Query.prototype.read = function (pref) {
+Query.prototype.read = function(pref) {
   if (arguments.length > 1 && !Query.prototype.read.deprecationWarningIssued) {
-    console.error("Deprecation warning: 'tags' argument is not supported anymore in Query.read() method. Please use mongodb.ReadPreference object instead.");
+    console.error('Deprecation warning: \'tags\' argument is not supported anymore in Query.read() method. Please use mongodb.ReadPreference object instead.');
     Query.prototype.read.deprecationWarningIssued = true;
   }
   this.options.readPreference = utils.readPref(pref);
   return this;
-}
+};
 
 /**
  * Sets the readConcern option for the query.
@@ -1677,10 +1680,10 @@ Query.prototype.read = function (pref) {
  * @api public
  */
 
-Query.prototype.readConcern = function (level) {
-  this.options.readConcern = utils.readConcern(level)
-  return this
-}
+Query.prototype.readConcern = function(level) {
+  this.options.readConcern = utils.readConcern(level);
+  return this;
+};
 
 /**
  * Sets tailable option.
@@ -1700,15 +1703,15 @@ Query.prototype.readConcern = function (level) {
  * @api public
  */
 
-Query.prototype.tailable = function () {
+Query.prototype.tailable = function() {
   this._validate('tailable');
 
   this.options.tailable = arguments.length
-    ? !! arguments[0]
+    ? !!arguments[0]
     : true;
 
   return this;
-}
+};
 
 /**
  * Merges another Query or conditions object into this one.
@@ -1719,7 +1722,7 @@ Query.prototype.tailable = function () {
  * @return {Query} this
  */
 
-Query.prototype.merge = function (source) {
+Query.prototype.merge = function(source) {
   if (!source)
     return this;
 
@@ -1759,7 +1762,7 @@ Query.prototype.merge = function (source) {
   utils.merge(this._conditions, source);
 
   return this;
-}
+};
 
 /**
  * Finds documents.
@@ -1778,7 +1781,7 @@ Query.prototype.merge = function (source) {
  * @api public
  */
 
-Query.prototype.find = function (criteria, callback) {
+Query.prototype.find = function(criteria, callback) {
   this.op = 'find';
 
   if ('function' === typeof criteria) {
@@ -1790,21 +1793,20 @@ Query.prototype.find = function (criteria, callback) {
 
   if (!callback) return this;
 
-  var self = this
-    , conds = this._conditions
-    , options = this._optionsForExec()
+  var conds = this._conditions,
+      options = this._optionsForExec();
 
-  options.fields = this._fieldsForExec()
+  options.fields = this._fieldsForExec();
 
   debug('find', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('find', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.find(conds, options, utils.tick(callback));
   return this;
-}
+};
 
 /**
  * Returns the query cursor
@@ -1819,23 +1821,23 @@ Query.prototype.find = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.cursor = function cursor (criteria) {
+Query.prototype.cursor = function cursor(criteria) {
   if (this.op) {
     if (this.op !== 'find') {
-      throw new TypeError(".cursor only support .find method");
+      throw new TypeError('.cursor only support .find method');
     }
   } else {
     this.find(criteria);
   }
 
-  var conds = this._conditions
-    , options = this._optionsForExec()
+  var conds = this._conditions,
+      options = this._optionsForExec();
 
-  options.fields = this._fieldsForExec()
+  options.fields = this._fieldsForExec();
 
   debug('findCursor', this._collection.collectionName, conds, options);
   return this._collection.findCursor(conds, options);
-}
+};
 
 /**
  * Executes the query as a findOne() operation.
@@ -1864,7 +1866,7 @@ Query.prototype.cursor = function cursor (criteria) {
  * @api public
  */
 
-Query.prototype.findOne = function (criteria, callback) {
+Query.prototype.findOne = function(criteria, callback) {
   this.op = 'findOne';
 
   if ('function' === typeof criteria) {
@@ -1876,22 +1878,21 @@ Query.prototype.findOne = function (criteria, callback) {
 
   if (!callback) return this;
 
-  var self = this
-    , conds = this._conditions
-    , options = this._optionsForExec()
+  var conds = this._conditions,
+      options = this._optionsForExec();
 
   options.fields = this._fieldsForExec();
 
   debug('findOne', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('findOne', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.findOne(conds, options, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Exectues the query as a count() operation.
@@ -1918,7 +1919,7 @@ Query.prototype.findOne = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.count = function (criteria, callback) {
+Query.prototype.count = function(criteria, callback) {
   this.op = 'count';
   this._validate();
 
@@ -1931,18 +1932,18 @@ Query.prototype.count = function (criteria, callback) {
 
   if (!callback) return this;
 
-  var conds = this._conditions
-    , options = this._optionsForExec()
+  var conds = this._conditions,
+      options = this._optionsForExec();
 
   debug('count', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('count', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.count(conds, options, utils.tick(callback));
   return this;
-}
+};
 
 /**
  * Declares or executes a distinct() operation.
@@ -1966,7 +1967,7 @@ Query.prototype.count = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.distinct = function (criteria, field, callback) {
+Query.prototype.distinct = function(criteria, field, callback) {
   this.op = 'distinct';
   this._validate();
 
@@ -1983,8 +1984,7 @@ Query.prototype.distinct = function (criteria, field, callback) {
       case 'string':
         break;
       default:
-        throw new TypeError('Invalid `field` argument. Must be string or function')
-        break;
+        throw new TypeError('Invalid `field` argument. Must be string or function');
     }
 
     switch (typeof criteria) {
@@ -2015,19 +2015,19 @@ Query.prototype.distinct = function (criteria, field, callback) {
     throw new Error('No value for `distinct` has been declared');
   }
 
-  var conds = this._conditions
-    , options = this._optionsForExec()
+  var conds = this._conditions,
+      options = this._optionsForExec();
 
   debug('distinct', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('distinct', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.distinct(this._distinct, conds, options, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Declare and/or execute this query as an update() operation. By default,
@@ -2107,7 +2107,7 @@ Query.prototype.distinct = function (criteria, field, callback) {
  * @api public
  */
 
-Query.prototype.update = function update (criteria, doc, options, callback) {
+Query.prototype.update = function update(criteria, doc, options, callback) {
   var force;
 
   switch (arguments.length) {
@@ -2143,7 +2143,7 @@ Query.prototype.update = function update (criteria, doc, options, callback) {
   }
 
   return _update(this, 'update', criteria, doc, options, force, callback);
-}
+};
 
 /**
  * Declare and/or execute this query as an `updateMany()` operation. Identical
@@ -2165,7 +2165,7 @@ Query.prototype.update = function update (criteria, doc, options, callback) {
  * @api public
  */
 
-Query.prototype.updateMany = function updateMany (criteria, doc, options, callback) {
+Query.prototype.updateMany = function updateMany(criteria, doc, options, callback) {
   var force;
 
   switch (arguments.length) {
@@ -2201,7 +2201,7 @@ Query.prototype.updateMany = function updateMany (criteria, doc, options, callba
   }
 
   return _update(this, 'updateMany', criteria, doc, options, force, callback);
-}
+};
 
 /**
  * Declare and/or execute this query as an `updateOne()` operation. Identical
@@ -2223,7 +2223,7 @@ Query.prototype.updateMany = function updateMany (criteria, doc, options, callba
  * @api public
  */
 
-Query.prototype.updateOne = function updateOne (criteria, doc, options, callback) {
+Query.prototype.updateOne = function updateOne(criteria, doc, options, callback) {
   var force;
 
   switch (arguments.length) {
@@ -2259,7 +2259,7 @@ Query.prototype.updateOne = function updateOne (criteria, doc, options, callback
   }
 
   return _update(this, 'updateOne', criteria, doc, options, force, callback);
-}
+};
 
 /**
  * Declare and/or execute this query as an `replaceOne()` operation. Similar
@@ -2280,7 +2280,7 @@ Query.prototype.updateOne = function updateOne (criteria, doc, options, callback
  * @api public
  */
 
-Query.prototype.replaceOne = function replaceOne (criteria, doc, options, callback) {
+Query.prototype.replaceOne = function replaceOne(criteria, doc, options, callback) {
   var force;
 
   switch (arguments.length) {
@@ -2317,14 +2317,14 @@ Query.prototype.replaceOne = function replaceOne (criteria, doc, options, callba
 
   this.setOptions({ overwrite: true });
   return _update(this, 'replaceOne', criteria, doc, options, force, callback);
-}
+};
 
 
 /*!
  * Internal helper for update, updateMany, updateOne
  */
 
-function _update (query, op, criteria, doc, options, force, callback) {
+function _update(query, op, criteria, doc, options, force, callback) {
   query.op = op;
 
   if (Query.canMerge(criteria)) {
@@ -2355,14 +2355,14 @@ function _update (query, op, criteria, doc, options, force, callback) {
   options = query._optionsForExec();
   if (!callback) options.safe = false;
 
-  var criteria = query._conditions;
+  criteria = query._conditions;
   doc = query._updateForExec();
 
   debug('update', query._collection.collectionName, criteria, doc, options);
   callback = query._wrapCallback(op, callback, {
-    conditions: criteria
-  , doc: doc
-  , options: options
+    conditions: criteria,
+    doc: doc,
+    options: options
   });
 
   query._collection[op](criteria, doc, options, utils.tick(callback));
@@ -2403,7 +2403,7 @@ function _update (query, op, criteria, doc, options, force, callback) {
  * @api public
  */
 
-Query.prototype.remove = function (criteria, callback) {
+Query.prototype.remove = function(criteria, callback) {
   this.op = 'remove';
   var force;
 
@@ -2420,21 +2420,21 @@ Query.prototype.remove = function (criteria, callback) {
   if (!(force || callback))
     return this;
 
-  var options = this._optionsForExec()
+  var options = this._optionsForExec();
   if (!callback) options.safe = false;
 
   var conds = this._conditions;
 
   debug('remove', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('remove', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.remove(conds, options, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Declare and/or execute this query as a `deleteOne()` operation. Behaves like
@@ -2451,7 +2451,7 @@ Query.prototype.remove = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.deleteOne = function (criteria, callback) {
+Query.prototype.deleteOne = function(criteria, callback) {
   this.op = 'deleteOne';
   var force;
 
@@ -2468,7 +2468,7 @@ Query.prototype.deleteOne = function (criteria, callback) {
   if (!(force || callback))
     return this;
 
-  var options = this._optionsForExec()
+  var options = this._optionsForExec();
   if (!callback) options.safe = false;
   delete options.justOne;
 
@@ -2476,14 +2476,14 @@ Query.prototype.deleteOne = function (criteria, callback) {
 
   debug('deleteOne', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('deleteOne', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.deleteOne(conds, options, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Declare and/or execute this query as a `deleteMany()` operation. Behaves like
@@ -2500,7 +2500,7 @@ Query.prototype.deleteOne = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.deleteMany = function (criteria, callback) {
+Query.prototype.deleteMany = function(criteria, callback) {
   this.op = 'deleteMany';
   var force;
 
@@ -2517,7 +2517,7 @@ Query.prototype.deleteMany = function (criteria, callback) {
   if (!(force || callback))
     return this;
 
-  var options = this._optionsForExec()
+  var options = this._optionsForExec();
   if (!callback) options.safe = false;
   delete options.justOne;
 
@@ -2525,14 +2525,14 @@ Query.prototype.deleteMany = function (criteria, callback) {
 
   debug('deleteOne', this._collection.collectionName, conds, options);
   callback = this._wrapCallback('deleteOne', callback, {
-    conditions: conds
-  , options: options
+    conditions: conds,
+    options: options
   });
 
   this._collection.deleteMany(conds, options, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Issues a mongodb [findAndModify](http://www.mongodb.org/display/DOCS/findAndModify+Command) update command.
@@ -2565,7 +2565,7 @@ Query.prototype.deleteMany = function (criteria, callback) {
  * @api public
  */
 
-Query.prototype.findOneAndUpdate = function (criteria, doc, options, callback) {
+Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
   this.op = 'findOneAndUpdate';
   this._validate();
 
@@ -2607,7 +2607,7 @@ Query.prototype.findOneAndUpdate = function (criteria, doc, options, callback) {
 
   if (!callback) return this;
   return this._findAndModify('update', callback);
-}
+};
 
 /**
  * Issues a mongodb [findAndModify](http://www.mongodb.org/display/DOCS/findAndModify+Command) remove command.
@@ -2635,7 +2635,7 @@ Query.prototype.findOneAndUpdate = function (criteria, doc, options, callback) {
  * @api public
  */
 
-Query.prototype.findOneAndRemove = function (conditions, options, callback) {
+Query.prototype.findOneAndRemove = function(conditions, options, callback) {
   this.op = 'findOneAndRemove';
   this._validate();
 
@@ -2658,7 +2658,7 @@ Query.prototype.findOneAndRemove = function (conditions, options, callback) {
   if (!callback) return this;
 
   return this._findAndModify('remove', callback);
-}
+};
 
 /**
  * _findAndModify
@@ -2668,14 +2668,12 @@ Query.prototype.findOneAndRemove = function (conditions, options, callback) {
  * @api private
  */
 
-Query.prototype._findAndModify = function (type, callback) {
+Query.prototype._findAndModify = function(type, callback) {
   assert.equal('function', typeof callback);
 
-  var opts = this._optionsForExec()
-    , self = this
-    , fields
-    , sort
-    , doc
+  var opts = this._optionsForExec(),
+      fields,
+      doc;
 
   if ('remove' == type) {
     opts.remove = true;
@@ -2683,7 +2681,7 @@ Query.prototype._findAndModify = function (type, callback) {
     if (!('new' in opts)) opts.new = true;
     if (!('upsert' in opts)) opts.upsert = false;
 
-    doc = this._updateForExec()
+    doc = this._updateForExec();
     if (!doc) {
       if (opts.upsert) {
         // still need to do the upsert to empty doc
@@ -2694,7 +2692,7 @@ Query.prototype._findAndModify = function (type, callback) {
     }
   }
 
-  var fields = this._fieldsForExec();
+  fields = this._fieldsForExec();
   if (fields) {
     opts.fields = fields;
   }
@@ -2703,16 +2701,16 @@ Query.prototype._findAndModify = function (type, callback) {
 
   debug('findAndModify', this._collection.collectionName, conds, doc, opts);
   callback = this._wrapCallback('findAndModify', callback, {
-    conditions: conds
-  , doc: doc
-  , options: opts
+    conditions: conds,
+    doc: doc,
+    options: opts
   });
 
   this._collection
-  .findAndModify(conds, doc, opts, utils.tick(callback));
+    .findAndModify(conds, doc, opts, utils.tick(callback));
 
   return this;
-}
+};
 
 /**
  * Wrap callback to add tracing
@@ -2721,7 +2719,7 @@ Query.prototype._findAndModify = function (type, callback) {
  * @param {Object} [queryInfo]
  * @api private
  */
-Query.prototype._wrapCallback = function (method, callback, queryInfo) {
+Query.prototype._wrapCallback = function(method, callback, queryInfo) {
   var traceFunction = this._traceFunction || Query.traceFunction;
 
   if (traceFunction) {
@@ -2732,7 +2730,7 @@ Query.prototype._wrapCallback = function (method, callback, queryInfo) {
 
     var startTime = new Date().getTime();
 
-    return function wrapperCallback (err, result) {
+    return function wrapperCallback(err, result) {
       if (traceCallback) {
         var millis = new Date().getTime() - startTime;
         traceCallback.call(null, err, result, millis);
@@ -2745,7 +2743,7 @@ Query.prototype._wrapCallback = function (method, callback, queryInfo) {
   }
 
   return callback;
-}
+};
 
 /**
  * Add trace function that gets called when the query is executed.
@@ -2766,10 +2764,10 @@ Query.prototype._wrapCallback = function (method, callback, queryInfo) {
  * @return {Query} this
  * @api public
  */
-Query.prototype.setTraceFunction = function (traceFunction) {
+Query.prototype.setTraceFunction = function(traceFunction) {
   this._traceFunction = traceFunction;
   return this;
-}
+};
 
 /**
  * Executes the query
@@ -2786,7 +2784,7 @@ Query.prototype.setTraceFunction = function (traceFunction) {
  * @api public
  */
 
-Query.prototype.exec = function exec (op, callback) {
+Query.prototype.exec = function exec(op, callback) {
   switch (typeof op) {
     case 'function':
       callback = op;
@@ -2797,26 +2795,26 @@ Query.prototype.exec = function exec (op, callback) {
       break;
   }
 
-  assert.ok(this.op, "Missing query type: (find, update, etc)");
+  assert.ok(this.op, 'Missing query type: (find, update, etc)');
 
   if ('update' == this.op || 'remove' == this.op) {
     callback || (callback = true);
   }
 
-  var self = this;
+  var _this = this;
 
   if ('function' == typeof callback) {
     this[this.op](callback);
   } else {
     return new Query.Promise(function(success, error) {
-      self[self.op](function(err, val) {
+      _this[_this.op](function(err, val) {
         if (err) error(err);
         else success(val);
-        self = success = error = null;
+        success = error = null;
       });
     });
   }
-}
+};
 
 /**
  * Returns a thunk which when called runs this.exec()
@@ -2829,11 +2827,11 @@ Query.prototype.exec = function exec (op, callback) {
  */
 
 Query.prototype.thunk = function() {
-  var self = this;
+  var _this = this;
   return function(cb) {
-    self.exec(cb);
-  }
-}
+    _this.exec(cb);
+  };
+};
 
 /**
  * Executes the query returning a `Promise` which will be
@@ -2846,16 +2844,16 @@ Query.prototype.thunk = function() {
  */
 
 Query.prototype.then = function(resolve, reject) {
-  var self = this;
+  var _this = this;
   var promise = new Query.Promise(function(success, error) {
-    self.exec(function(err, val) {
+    _this.exec(function(err, val) {
       if (err) error(err);
       else success(val);
-      self = success = error = null;
+      success = error = null;
     });
   });
   return promise.then(resolve, reject);
-}
+};
 
 /**
  * Returns a stream for the given find query.
@@ -2870,13 +2868,13 @@ Query.prototype.stream = function(streamOptions) {
 
   var conds = this._conditions;
 
-  var options = this._optionsForExec()
-  options.fields = this._fieldsForExec()
+  var options = this._optionsForExec();
+  options.fields = this._fieldsForExec();
 
   debug('stream', this._collection.collectionName, conds, options, streamOptions);
 
   return this._collection.findStream(conds, options, streamOptions);
-}
+};
 
 /**
  * Determines if field selection has been made.
@@ -2885,9 +2883,9 @@ Query.prototype.stream = function(streamOptions) {
  * @api public
  */
 
-Query.prototype.selected = function selected () {
-  return !! (this._fields && Object.keys(this._fields).length > 0);
-}
+Query.prototype.selected = function selected() {
+  return !!(this._fields && Object.keys(this._fields).length > 0);
+};
 
 /**
  * Determines if inclusive field selection has been made.
@@ -2900,7 +2898,7 @@ Query.prototype.selected = function selected () {
  * @returns {Boolean}
  */
 
-Query.prototype.selectedInclusively = function selectedInclusively () {
+Query.prototype.selectedInclusively = function selectedInclusively() {
   if (!this._fields) return false;
 
   var keys = Object.keys(this._fields);
@@ -2917,7 +2915,7 @@ Query.prototype.selectedInclusively = function selectedInclusively () {
   }
 
   return true;
-}
+};
 
 /**
  * Determines if exclusive field selection has been made.
@@ -2930,7 +2928,7 @@ Query.prototype.selectedInclusively = function selectedInclusively () {
  * @returns {Boolean}
  */
 
-Query.prototype.selectedExclusively = function selectedExclusively () {
+Query.prototype.selectedExclusively = function selectedExclusively() {
   if (!this._fields) return false;
 
   var keys = Object.keys(this._fields);
@@ -2942,7 +2940,7 @@ Query.prototype.selectedExclusively = function selectedExclusively () {
   }
 
   return false;
-}
+};
 
 /**
  * Merges `doc` with the current update object.
@@ -2950,7 +2948,7 @@ Query.prototype.selectedExclusively = function selectedExclusively () {
  * @param {Object} doc
  */
 
-Query.prototype._mergeUpdate = function (doc) {
+Query.prototype._mergeUpdate = function(doc) {
   if (!this._update) this._update = {};
   if (doc instanceof Query) {
     if (doc._update) {
@@ -2959,7 +2957,7 @@ Query.prototype._mergeUpdate = function (doc) {
   } else {
     utils.mergeClone(this._update, doc);
   }
-}
+};
 
 /**
  * Returns default options.
@@ -2968,10 +2966,10 @@ Query.prototype._mergeUpdate = function (doc) {
  * @api private
  */
 
-Query.prototype._optionsForExec = function () {
+Query.prototype._optionsForExec = function() {
   var options = utils.clone(this.options);
   return options;
-}
+};
 
 /**
  * Returns fields selection for this query.
@@ -2980,9 +2978,9 @@ Query.prototype._optionsForExec = function () {
  * @api private
  */
 
-Query.prototype._fieldsForExec = function () {
+Query.prototype._fieldsForExec = function() {
   return utils.clone(this._fields);
-}
+};
 
 /**
  * Return an update document with corrected $set operations.
@@ -2990,13 +2988,11 @@ Query.prototype._fieldsForExec = function () {
  * @api private
  */
 
-Query.prototype._updateForExec = function () {
-  var update = utils.clone(this._update)
-    , ops = utils.keys(update)
-    , i = ops.length
-    , ret = {}
-    , hasKeys
-    , val
+Query.prototype._updateForExec = function() {
+  var update = utils.clone(this._update),
+      ops = utils.keys(update),
+      i = ops.length,
+      ret = {};
 
   while (i--) {
     var op = ops[i];
@@ -3029,7 +3025,7 @@ Query.prototype._updateForExec = function () {
 
   this._compiledUpdate = ret;
   return ret;
-}
+};
 
 /**
  * Make sure _path is set.
@@ -3037,13 +3033,13 @@ Query.prototype._updateForExec = function () {
  * @parmam {String} method
  */
 
-Query.prototype._ensurePath = function (method) {
+Query.prototype._ensurePath = function(method) {
   if (!this._path) {
     var msg = method + '() must be used after where() '
-                     + 'when called with these arguments'
+                     + 'when called with these arguments';
     throw new Error(msg);
   }
-}
+};
 
 /*!
  * Permissions
@@ -3051,13 +3047,13 @@ Query.prototype._ensurePath = function (method) {
 
 Query.permissions = require('./permissions');
 
-Query._isPermitted = function (a, b) {
+Query._isPermitted = function(a, b) {
   var denied = Query.permissions[b];
   if (!denied) return true;
   return true !== denied[a];
-}
+};
 
-Query.prototype._validate = function (action) {
+Query.prototype._validate = function(action) {
   var fail;
   var validator;
 
@@ -3075,7 +3071,7 @@ Query.prototype._validate = function (action) {
   if (fail) {
     throw new Error(fail + ' cannot be used with ' + this.op);
   }
-}
+};
 
 /**
  * Determines if `conds` can be merged using `mquery().merge()`
@@ -3084,9 +3080,9 @@ Query.prototype._validate = function (action) {
  * @return {Boolean}
  */
 
-Query.canMerge = function (conds) {
+Query.canMerge = function(conds) {
   return conds instanceof Query || utils.isObject(conds);
-}
+};
 
 /**
  * Set a trace function that will get called whenever a
@@ -3097,16 +3093,16 @@ Query.canMerge = function (conds) {
  * @param {Object} conds
  * @return {Boolean}
  */
-Query.setGlobalTraceFunction = function (traceFunction) {
+Query.setGlobalTraceFunction = function(traceFunction) {
   Query.traceFunction = traceFunction;
-}
+};
 
 /*!
  * Exports.
  */
 
 Query.utils = utils;
-Query.env = require('./env')
+Query.env = require('./env');
 Query.Collection = require('./collection');
 Query.BaseCollection = require('./collection/collection');
 Query.Promise = require('bluebird');

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -2,15 +2,15 @@
 
 var denied = exports;
 
-denied.distinct = function (self) {
+denied.distinct = function(self) {
   if (self._fields && Object.keys(self._fields).length > 0) {
-    return 'field selection and slice'
+    return 'field selection and slice';
   }
 
   var keys = Object.keys(denied.distinct);
   var err;
 
-  keys.every(function (option) {
+  keys.every(function(option) {
     if (self.options[option]) {
       err = option;
       return false;
@@ -37,11 +37,11 @@ denied.distinct.tailable = true;
 
 
 denied.findOneAndUpdate =
-denied.findOneAndRemove = function (self) {
+denied.findOneAndRemove = function(self) {
   var keys = Object.keys(denied.findOneAndUpdate);
   var err;
 
-  keys.every(function (option) {
+  keys.every(function(option) {
     if (self.options[option]) {
       err = option;
       return false;
@@ -50,7 +50,7 @@ denied.findOneAndRemove = function (self) {
   });
 
   return err;
-}
+};
 denied.findOneAndUpdate.limit =
 denied.findOneAndUpdate.skip =
 denied.findOneAndUpdate.batchSize =
@@ -61,15 +61,15 @@ denied.findOneAndUpdate.tailable =
 denied.findOneAndUpdate.comment = true;
 
 
-denied.count = function (self) {
+denied.count = function(self) {
   if (self._fields && Object.keys(self._fields).length > 0) {
-    return 'field selection and slice'
+    return 'field selection and slice';
   }
 
   var keys = Object.keys(denied.count);
   var err;
 
-  keys.every(function (option) {
+  keys.every(function(option) {
     if (self.options[option]) {
       err = option;
       return false;
@@ -78,7 +78,7 @@ denied.count = function (self) {
   });
 
   return err;
-}
+};
 
 denied.count.slice =
 denied.count.batchSize =

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,7 @@
  * Module dependencies.
  */
 
-var RegExpClone = require('regexp-clone')
+var RegExpClone = require('regexp-clone');
 
 /**
  * Clones objects
@@ -15,7 +15,7 @@ var RegExpClone = require('regexp-clone')
  * @api private
  */
 
-var clone = exports.clone = function clone (obj, options) {
+var clone = exports.clone = function clone(obj, options) {
   if (obj === undefined || obj === null)
     return obj;
 
@@ -62,14 +62,12 @@ var clone = exports.clone = function clone (obj, options) {
  * ignore
  */
 
-var cloneObject = exports.cloneObject = function cloneObject (obj, options) {
+exports.cloneObject = function cloneObject(obj, options) {
   var minimize = options && options.minimize;
   var ret = {};
   var hasKeys;
-  var keys;
   var val;
   var k;
-  var i;
 
   for (k in obj) {
     val = clone(obj[k], options);
@@ -85,7 +83,7 @@ var cloneObject = exports.cloneObject = function cloneObject (obj, options) {
     : ret;
 };
 
-var cloneArray = exports.cloneArray = function cloneArray (arr, options) {
+exports.cloneArray = function cloneArray(arr, options) {
   var ret = [];
   for (var i = 0, l = arr.length; i < l; i++)
     ret.push(clone(arr[i], options));
@@ -106,20 +104,20 @@ var cloneArray = exports.cloneArray = function cloneArray (arr, options) {
  * @api private
  */
 
-var tick = exports.tick = function tick (callback) {
+exports.tick = function tick(callback) {
   if ('function' !== typeof callback) return;
-  return function () {
+  return function() {
     // callbacks should always be fired on the next
     // turn of the event loop. A side benefit is
     // errors thrown from executing the callback
     // will not cause drivers state to be corrupted
     // which has historically been a problem.
     var args = arguments;
-    soon(function(){
+    soon(function() {
       callback.apply(this, args);
     });
-  }
-}
+  };
+};
 
 /**
  * Merges `from` into `to` without overwriting existing properties.
@@ -129,10 +127,10 @@ var tick = exports.tick = function tick (callback) {
  * @api private
  */
 
-var merge = exports.merge = function merge (to, from) {
-  var keys = Object.keys(from)
-    , i = keys.length
-    , key
+exports.merge = function merge(to, from) {
+  var keys = Object.keys(from),
+      i = keys.length,
+      key;
 
   while (i--) {
     key = keys[i];
@@ -146,7 +144,7 @@ var merge = exports.merge = function merge (to, from) {
       }
     }
   }
-}
+};
 
 /**
  * Same as merge but clones the assigned values.
@@ -156,10 +154,10 @@ var merge = exports.merge = function merge (to, from) {
  * @api private
  */
 
-var mergeClone = exports.mergeClone = function mergeClone (to, from) {
-  var keys = Object.keys(from)
-    , i = keys.length
-    , key
+exports.mergeClone = function mergeClone(to, from) {
+  var keys = Object.keys(from),
+      i = keys.length,
+      key;
 
   while (i--) {
     key = keys[i];
@@ -173,7 +171,7 @@ var mergeClone = exports.mergeClone = function mergeClone (to, from) {
       }
     }
   }
-}
+};
 
 /**
  * Read pref helper (mongo 2.2 drivers support this)
@@ -189,7 +187,7 @@ var mergeClone = exports.mergeClone = function mergeClone (to, from) {
  * @param {String} pref
  */
 
-exports.readPref = function readPref (pref) {
+exports.readPref = function readPref(pref) {
   switch (pref) {
     case 'p':
       pref = 'primary';
@@ -209,7 +207,7 @@ exports.readPref = function readPref (pref) {
   }
 
   return pref;
-}
+};
 
 
 /**
@@ -226,11 +224,11 @@ exports.readPref = function readPref (pref) {
  * @param {String} readConcern
  */
 
-exports.readConcern = function readConcern (concern) {
+exports.readConcern = function readConcern(concern) {
   if ('string' === typeof concern) {
     switch (concern) {
       case 'l':
-        concern = 'local'
+        concern = 'local';
         break;
       case 'a':
         concern = 'available';
@@ -245,19 +243,19 @@ exports.readConcern = function readConcern (concern) {
         concern = 'snapshot';
         break;
     }
-    concern = { level: concern }
+    concern = { level: concern };
   }
-  return concern
-}
+  return concern;
+};
 
 /**
  * Object.prototype.toString.call helper
  */
 
 var _toString = Object.prototype.toString;
-var toString = exports.toString = function (arg) {
+exports.toString = function(arg) {
   return _toString.call(arg);
-}
+};
 
 /**
  * Determines if `arg` is an object.
@@ -266,9 +264,9 @@ var toString = exports.toString = function (arg) {
  * @return {Boolean}
  */
 
-var isObject = exports.isObject = function (arg) {
+var isObject = exports.isObject = function(arg) {
   return '[object Object]' == exports.toString(arg);
-}
+};
 
 /**
  * Determines if `arg` is an array.
@@ -278,22 +276,22 @@ var isObject = exports.isObject = function (arg) {
  * @see nodejs utils
  */
 
-var isArray = exports.isArray = function (arg) {
+exports.isArray = function(arg) {
   return Array.isArray(arg) ||
     'object' == typeof arg && '[object Array]' == exports.toString(arg);
-}
+};
 
 /**
  * Object.keys helper
  */
 
-exports.keys = Object.keys || function (obj) {
+exports.keys = Object.keys || function(obj) {
   var keys = [];
   for (var k in obj) if (obj.hasOwnProperty(k)) {
     keys.push(k);
   }
   return keys;
-}
+};
 
 /**
  * Basic Object.create polyfill.
@@ -306,12 +304,12 @@ exports.create = 'function' == typeof Object.create
   ? Object.create
   : create;
 
-function create (proto) {
+function create(proto) {
   if (arguments.length > 1) {
-    throw new Error("Adding properties is not supported")
+    throw new Error('Adding properties is not supported');
   }
 
-  function F () {}
+  function F() {}
   F.prototype = proto;
   return new F;
 }
@@ -320,10 +318,10 @@ function create (proto) {
  * inheritance
  */
 
-exports.inherits = function (ctor, superCtor) {
+exports.inherits = function(ctor, superCtor) {
   ctor.prototype = exports.create(superCtor.prototype);
   ctor.prototype.constructor = ctor;
-}
+};
 
 /**
  * nextTick helper
@@ -341,7 +339,7 @@ var soon = exports.soon = 'function' == typeof setImmediate
  * @return {Buffer}
  */
 
-exports.cloneBuffer = function (buff) {
+exports.cloneBuffer = function(buff) {
   var dupe = Buffer.alloc(buff.length);
   buff.copy(dupe, 0, 0, buff.length);
   return dupe;

--- a/package-lock.json
+++ b/package-lock.json
@@ -153,9 +153,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bluebird": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -315,13 +315,10 @@
       "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -355,9 +352,9 @@
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -389,9 +386,9 @@
       }
     },
     "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "doctrine": {
@@ -684,16 +681,10 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "handlebars": {
@@ -731,6 +722,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
     "iconv-lite": {
@@ -891,12 +888,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -926,74 +917,6 @@
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true,
-      "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
-      }
     },
     "longest": {
       "version": "1.0.1",
@@ -1037,61 +960,51 @@
       }
     },
     "mocha": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.2.0.tgz",
-      "integrity": "sha1-fcT0XlCIB1FxpoiWgU5q6et6heM=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+      "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.0.5",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
         "glob": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
-          "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "has-flag": "^2.0.0"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -1138,289 +1051,6 @@
       "dev": true,
       "requires": {
         "abbrev": "1"
-      }
-    },
-    "nsp": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/nsp/-/nsp-2.8.1.tgz",
-      "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "cli-table": "^0.3.1",
-        "cvss": "^1.0.0",
-        "https-proxy-agent": "^1.0.0",
-        "joi": "^6.9.1",
-        "nodesecurity-npm-utils": "^5.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rc": "^1.1.2",
-        "semver": "^5.0.3",
-        "subcommand": "^2.0.3",
-        "wreck": "^6.3.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-          "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-          "dev": true,
-          "requires": {
-            "extend": "~3.0.0",
-            "semver": "~5.0.1"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.0.3",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-              "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-              "dev": true
-            }
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "cli-table": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-          "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-          "dev": true,
-          "requires": {
-            "colors": "1.0.3"
-          }
-        },
-        "cliclopts": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
-          "dev": true
-        },
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        },
-        "cvss": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/cvss/-/cvss-1.0.2.tgz",
-          "integrity": "sha1-32fpK/EqeW9J6Sh5nI2zunS5/NY=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-          "dev": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        },
-        "https-proxy-agent": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-          "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-          "dev": true,
-          "requires": {
-            "agent-base": "2",
-            "debug": "2",
-            "extend": "3"
-          }
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        },
-        "isemail": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-          "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-          "dev": true
-        },
-        "joi": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-          "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x",
-            "isemail": "1.x.x",
-            "moment": "2.x.x",
-            "topo": "1.x.x"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "nodesecurity-npm-utils": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/nodesecurity-npm-utils/-/nodesecurity-npm-utils-5.0.0.tgz",
-          "integrity": "sha1-Baow3jDKjIRcQEjpT9eOXgi1Xtk=",
-          "dev": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-          "dev": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
-          "dev": true,
-          "requires": {
-            "deep-extend": "~0.4.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
-        },
-        "subcommand": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/subcommand/-/subcommand-2.1.0.tgz",
-          "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
-          "dev": true,
-          "requires": {
-            "cliclopts": "^1.1.0",
-            "debug": "^2.1.3",
-            "minimist": "^1.2.0",
-            "xtend": "^4.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "topo": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-          "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.x.x"
-          }
-        },
-        "wreck": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/wreck/-/wreck-6.3.0.tgz",
-          "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
-          "dev": true,
-          "requires": {
-            "boom": "2.x.x",
-            "hoek": "2.x.x"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-          "dev": true
-        }
       }
     },
     "object-assign": {
@@ -1706,9 +1336,9 @@
       }
     },
     "sliced": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-      "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "source-map": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,51 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
+    "acorn": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "^3.0.4"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+        }
+      }
+    },
+    "ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
+      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo="
+    },
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -27,14 +63,46 @@
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
     },
+    "ansi-escapes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
     "async": {
       "version": "1.5.2",
@@ -42,11 +110,47 @@
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bluebird": {
       "version": "3.5.0",
@@ -57,9 +161,8 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -75,11 +178,28 @@
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw=",
       "dev": true
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+    },
     "buffer-shims": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-      "dev": true
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "requires": {
+        "callsites": "^0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
     },
     "camelcase": {
       "version": "1.2.1",
@@ -95,9 +215,65 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chardet": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
     },
     "cliui": {
       "version": "2.1.0",
@@ -106,8 +282,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -120,26 +296,63 @@
         }
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+    },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -159,14 +372,35 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "requires": {
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
+      }
     },
     "diff": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
       "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
       "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
     },
     "es6-promise": {
       "version": "3.2.1",
@@ -177,8 +411,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.8.1",
@@ -186,11 +419,108 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
+      }
+    },
+    "eslint": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.14.0.tgz",
+      "integrity": "sha512-Ul6CSGRjKscEyg0X/EeNs7o2XdnbTEOD1OM8cTjmx85RPcBJQrEhZLevhuJZNAE/vS2iVl5Uhgiqf3h5uLMCJQ==",
+      "requires": {
+        "ajv": "^5.3.0",
+        "babel-code-frame": "^6.22.0",
+        "chalk": "^2.1.0",
+        "concat-stream": "^1.6.0",
+        "cross-spawn": "^5.1.0",
+        "debug": "^3.1.0",
+        "doctrine": "^2.0.2",
+        "eslint-scope": "^3.7.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^3.5.2",
+        "esquery": "^1.0.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.0.1",
+        "ignore": "^3.3.3",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^3.0.6",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.9.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.3.0",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^4.0.1",
+        "text-table": "~0.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
+      "integrity": "sha512-W+B0SvF4gamyCTmUc+uITPY0989iXVfKvhwtmJocTaYoc/3khEHmEmvfY/Gn9HA9VV75jrQECsHizkNw1b68FA==",
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "requires": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -198,6 +528,36 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
       "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "requires": {
+        "estraverse": "^4.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "requires": {
+        "estraverse": "^4.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        }
+      }
     },
     "estraverse": {
       "version": "1.9.3",
@@ -208,20 +568,70 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "external-editor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
+      "requires": {
+        "chardet": "^0.4.0",
+        "iconv-lite": "^0.4.17",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "requires": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "requires": {
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "glob": {
       "version": "5.0.15",
@@ -229,12 +639,50 @@
       "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
       "dev": true,
       "requires": {
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
+    },
+    "globals": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
+      "integrity": "sha512-K8BNSPySfeShBQXsahYB/AbbWruVOTyVpgoIDnl8odPpeSfP2J5QO2oLFFdl2j7GfDCtZj2bMKar2T49itTPCg=="
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "requires": {
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -254,10 +702,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "source-map": {
@@ -266,9 +714,17 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -277,21 +733,58 @@
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
     },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "inquirer": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "requires": {
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^2.0.4",
+        "figures": "^2.0.0",
+        "lodash": "^4.3.0",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rx-lite": "^4.0.8",
+        "rx-lite-aggregates": "^4.0.8",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
+      }
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -299,17 +792,51 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "requires": {
+        "is-path-inside": "^1.0.0"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "requires": {
+        "path-is-inside": "^1.0.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "istanbul": {
       "version": "0.4.5",
@@ -317,39 +844,52 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.1.2",
-        "which": "1.3.0",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         }
       }
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
     "json3": {
       "version": "3.3.2",
@@ -363,7 +903,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -377,11 +917,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
+    },
+    "lodash": {
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -389,8 +933,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -423,9 +967,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -446,9 +990,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "longest": {
@@ -457,26 +1001,37 @@
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
       "dev": true
     },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -515,12 +1070,12 @@
           "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -529,7 +1084,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "ms": {
@@ -557,8 +1112,8 @@
       "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
       "dev": true,
       "requires": {
-        "bson": "1.0.4",
-        "require_optional": "1.0.1"
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
       }
     },
     "ms": {
@@ -566,13 +1121,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+    },
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9"
+        "abbrev": "1"
       }
     },
     "nsp": {
@@ -581,17 +1146,17 @@
       "integrity": "sha512-jvjDg2Gsw4coD/iZ5eQddsDlkvnwMCNnpG05BproSnuG+Gr1bSQMwWMcQeYje+qdDl3XznmhblMPLpZLecTORQ==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "cli-table": "0.3.1",
-        "cvss": "1.0.2",
-        "https-proxy-agent": "1.0.0",
-        "joi": "6.10.1",
-        "nodesecurity-npm-utils": "5.0.0",
-        "path-is-absolute": "1.0.1",
-        "rc": "1.2.1",
-        "semver": "5.4.1",
-        "subcommand": "2.1.0",
-        "wreck": "6.3.0"
+        "chalk": "^1.1.1",
+        "cli-table": "^0.3.1",
+        "cvss": "^1.0.0",
+        "https-proxy-agent": "^1.0.0",
+        "joi": "^6.9.1",
+        "nodesecurity-npm-utils": "^5.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rc": "^1.1.2",
+        "semver": "^5.0.3",
+        "subcommand": "^2.0.3",
+        "wreck": "^6.3.0"
       },
       "dependencies": {
         "agent-base": {
@@ -600,8 +1165,8 @@
           "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
           "dev": true,
           "requires": {
-            "extend": "3.0.1",
-            "semver": "5.0.3"
+            "extend": "~3.0.0",
+            "semver": "~5.0.1"
           },
           "dependencies": {
             "semver": {
@@ -630,7 +1195,7 @@
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "chalk": {
@@ -639,11 +1204,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "cli-table": {
@@ -706,7 +1271,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "hoek": {
@@ -721,9 +1286,9 @@
           "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
           "dev": true,
           "requires": {
-            "agent-base": "2.1.1",
-            "debug": "2.6.9",
-            "extend": "3.0.1"
+            "agent-base": "2",
+            "debug": "2",
+            "extend": "3"
           }
         },
         "ini": {
@@ -744,10 +1309,10 @@
           "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3",
-            "isemail": "1.2.0",
-            "moment": "2.18.1",
-            "topo": "1.1.0"
+            "hoek": "2.x.x",
+            "isemail": "1.x.x",
+            "moment": "2.x.x",
+            "topo": "1.x.x"
           }
         },
         "minimist": {
@@ -786,10 +1351,10 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           }
         },
         "semver": {
@@ -804,7 +1369,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -819,10 +1384,10 @@
           "integrity": "sha1-XkzspaN3njNlsVEeBfhmh3MC92A=",
           "dev": true,
           "requires": {
-            "cliclopts": "1.1.1",
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "xtend": "4.0.1"
+            "cliclopts": "^1.1.0",
+            "debug": "^2.1.3",
+            "minimist": "^1.2.0",
+            "xtend": "^4.0.0"
           }
         },
         "supports-color": {
@@ -837,7 +1402,7 @@
           "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "wreck": {
@@ -846,8 +1411,8 @@
           "integrity": "sha1-oTaXafB7u2LWo3gzanhx/Hc8dAs=",
           "dev": true,
           "requires": {
-            "boom": "2.10.1",
-            "hoek": "2.16.3"
+            "boom": "2.x.x",
+            "hoek": "2.x.x"
           }
         },
         "xtend": {
@@ -858,13 +1423,25 @@
         }
       }
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
       }
     },
     "optimist": {
@@ -873,8 +1450,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -889,47 +1466,90 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
     },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-      "dev": true
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "readable-stream": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
       "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-      "dev": true,
       "requires": {
-        "buffer-shims": "1.0.0",
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "buffer-shims": "~1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~1.0.0",
+        "util-deprecate": "~1.0.1"
       }
     },
     "regexp-clone": {
@@ -943,14 +1563,30 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "requires": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        }
+      }
+    },
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
       "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0",
-        "semver": "5.4.1"
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
       }
     },
     "resolve": {
@@ -965,6 +1601,15 @@
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
       "dev": true
     },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -972,20 +1617,93 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rx-lite": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+    },
+    "rx-lite-aggregates": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+      "requires": {
+        "rx-lite": "*"
       }
     },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-      "dev": true
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slice-ansi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0"
+      }
     },
     "sliced": {
       "version": "0.0.5",
@@ -999,23 +1717,50 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
     },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "3.1.2",
@@ -1023,17 +1768,75 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
+      }
+    },
+    "table": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+      "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+      "requires": {
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
+        "slice-ansi": "1.0.0",
+        "string-width": "^2.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.1"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -1042,9 +1845,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -1063,19 +1866,25 @@
       "dev": true,
       "optional": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -1088,14 +1897,25 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.10.0",
@@ -1104,9 +1924,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Expressive query building for MongoDB",
   "main": "lib/mquery.js",
   "scripts": {
-    "test": "nsp check && mocha test/index.js test/*.test.js",
+    "test": "mocha test/index.js test/*.test.js",
     "fix-lint": "eslint . --fix",
     "lint": "eslint ."
   },
@@ -16,17 +16,16 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "bluebird": "3.5.0",
-    "debug": "2.6.9",
+    "bluebird": "3.5.1",
+    "debug": "3.1.0",
     "eslint": "4.14.0",
     "regexp-clone": "0.0.1",
-    "sliced": "0.0.5"
+    "sliced": "1.0.1"
   },
   "devDependencies": {
     "istanbul": "^0.4.5",
-    "mocha": "3.2.0",
-    "mongodb": "~2.2",
-    "nsp": "^2.8.1"
+    "mocha": "4.1.0",
+    "mongodb": "~2.2"
   },
   "bugs": {
     "url": "https://github.com/aheckmann/mquery/issues/new"

--- a/package.json
+++ b/package.json
@@ -4,15 +4,21 @@
   "description": "Expressive query building for MongoDB",
   "main": "lib/mquery.js",
   "scripts": {
-    "test": "nsp check && mocha test/index.js test/*.test.js"
+    "test": "nsp check && mocha test/index.js test/*.test.js",
+    "fix-lint": "eslint . --fix",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/aheckmann/mquery.git"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "dependencies": {
     "bluebird": "3.5.0",
     "debug": "2.6.9",
+    "eslint": "4.14.0",
     "regexp-clone": "0.0.1",
     "sliced": "0.0.5"
   },
@@ -32,5 +38,48 @@
     "query",
     "builder"
   ],
-  "homepage": "https://github.com/aheckmann/mquery/"
+  "homepage": "https://github.com/aheckmann/mquery/",
+  "eslintConfig": {
+    "env": {
+      "node": true,
+      "mocha": true,
+      "es6": false
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+      "ecmaVersion": 5
+    },
+    "rules": {
+      "comma-style": "error",
+      "consistent-this": [
+        "error",
+        "_this"
+      ],
+      "indent": [
+        "error",
+        2,
+        {
+          "SwitchCase": 1,
+          "VariableDeclarator": 2
+        }
+      ],
+      "keyword-spacing": "error",
+      "no-console": "off",
+      "no-multi-spaces": "error",
+      "func-call-spacing": "error",
+      "no-trailing-spaces": "error",
+      "quotes": [
+        "error",
+        "single"
+      ],
+      "semi": "error",
+      "space-before-blocks": "error",
+      "space-before-function-paren": [
+        "error",
+        "never"
+      ],
+      "space-infix-ops": "error",
+      "space-unary-ops": "error"
+    }
+  }
 }

--- a/test/collection/node.js
+++ b/test/collection/node.js
@@ -1,28 +1,26 @@
 
-var assert = require('assert')
-var slice = require('sliced')
-var mongo = require('mongodb')
-var utils = require('../../').utils;
+var assert = require('assert');
+var mongo = require('mongodb');
 
 var uri = process.env.MQUERY_URI || 'mongodb://localhost/mquery';
 var db;
 
-exports.getCollection = function (cb) {
-  mongo.MongoClient.connect(uri, function (err, db_) {
+exports.getCollection = function(cb) {
+  mongo.MongoClient.connect(uri, function(err, db_) {
     assert.ifError(err);
     db = db_;
 
     var collection = db.collection('stuff');
 
     // clean test db before starting
-    db.dropDatabase(function () {
+    db.dropDatabase(function() {
       cb(null, collection);
     });
-  })
-}
+  });
+};
 
-exports.dropCollection = function (cb) {
-  db.dropDatabase(function () {
+exports.dropCollection = function(cb) {
+  db.dropDatabase(function() {
     db.close(cb);
-  })
-}
+  });
+};

--- a/test/env.js
+++ b/test/env.js
@@ -1,5 +1,4 @@
 
-var assert = require('assert')
 var env = require('../').env;
 
 console.log('environment: %s', env.type);
@@ -11,8 +10,10 @@ switch (env.type) {
     break;
   case 'mongo':
     col = require('./collection/mongo');
+    break;
   case 'browser':
     col = require('./collection/browser');
+    break;
   default:
     throw new Error('missing collection implementation for environment: ' + env.type);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,62 +1,65 @@
 var mquery = require('../');
 var assert = require('assert');
 
-describe('mquery', function(){
+/* global Map */
+
+describe('mquery', function() {
   var col;
 
-  before(function(done){
+  before(function(done) {
     // get the env specific collection interface
-    require('./env').getCollection(function (err, collection) {
+    require('./env').getCollection(function(err, collection) {
       assert.ifError(err);
       col = collection;
       done();
     });
-  })
+  });
 
-  after(function(done){
+  after(function(done) {
     require('./env').dropCollection(done);
-  })
+  });
 
-  describe('mquery', function(){
-    it('is a function', function(){
+  describe('mquery', function() {
+    it('is a function', function() {
       assert.equal('function', typeof mquery);
-    })
-    it('creates instances with the `new` keyword', function(){
+    });
+    it('creates instances with the `new` keyword', function() {
       assert.ok(mquery() instanceof mquery);
-    })
-    describe('defaults', function(){
-      it('are set', function(){
+    });
+    describe('defaults', function() {
+      it('are set', function() {
         var m = mquery();
         assert.strictEqual(undefined, m.op);
         assert.deepEqual({}, m.options);
-      })
-    })
-    describe('criteria', function(){
-      it('if collection-like is used as collection', function(){
+      });
+    });
+    describe('criteria', function() {
+      it('if collection-like is used as collection', function() {
         var m = mquery(col);
         assert.equal(col, m._collection.collection);
-      })
-      it('non-collection-like is used as criteria', function(){
+      });
+      it('non-collection-like is used as criteria', function() {
         var m = mquery({ works: true });
         assert.ok(!m._collection);
         assert.deepEqual({ works: true }, m._conditions);
-      })
-    })
-    describe('options', function(){
-      it('are merged when passed', function(){
-        var m = mquery(col, { safe: true });
+      });
+    });
+    describe('options', function() {
+      it('are merged when passed', function() {
+        var m;
+        m = mquery(col, { safe: true });
         assert.deepEqual({ safe: true }, m.options);
-        var m = mquery({ name: 'mquery' }, { safe: true });
+        m = mquery({ name: 'mquery' }, { safe: true });
         assert.deepEqual({ safe: true }, m.options);
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('toConstructor', function(){
-    it('creates subclasses of mquery', function(){
+  describe('toConstructor', function() {
+    it('creates subclasses of mquery', function() {
       var opts = { safe: { w: 'majority' }, readPreference: 'p' };
       var match = { name: 'test', count: { $gt: 101 }};
-      var select = { name: 1, count: 0 }
+      var select = { name: 1, count: 0 };
       var update = { $set: { x: true }};
       var path = 'street';
 
@@ -77,900 +80,906 @@ describe('mquery', function(){
       assert.deepEqual(update, m._update);
       assert.equal(path, m._path);
       assert.equal('find', m.op);
-    })
-  })
+    });
+  });
 
-  describe('setOptions', function(){
-    it('calls associated methods', function(){
+  describe('setOptions', function() {
+    it('calls associated methods', function() {
       var m = mquery();
       assert.equal(m._collection, null);
       m.setOptions({ collection: col });
       assert.equal(m._collection.collection, col);
-    })
-    it('directly sets option when no method exists', function(){
+    });
+    it('directly sets option when no method exists', function() {
       var m = mquery();
       assert.equal(m.options.woot, null);
       m.setOptions({ woot: 'yay' });
       assert.equal(m.options.woot, 'yay');
-    })
-    it('is chainable', function(){
-      var m = mquery();
-      var n = m.setOptions();
-      assert.equal(m, n);
-      var n = m.setOptions({ x: 1 });
-      assert.equal(m, n);
-    })
-  })
+    });
+    it('is chainable', function() {
+      var m = mquery(),
+          n;
 
-  describe('collection', function(){
-    it('sets the _collection', function(){
+      n = m.setOptions();
+      assert.equal(m, n);
+      n = m.setOptions({ x: 1 });
+      assert.equal(m, n);
+    });
+  });
+
+  describe('collection', function() {
+    it('sets the _collection', function() {
       var m = mquery();
       m.collection(col);
       assert.equal(m._collection.collection, col);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       var n = m.collection(col);
       assert.equal(m, n);
-    })
-  })
+    });
+  });
 
-  describe('$where', function(){
-    it('sets the $where condition', function(){
+  describe('$where', function() {
+    it('sets the $where condition', function() {
       var m = mquery();
-      function go () {}
+      function go() {}
       m.$where(go);
       assert.ok(go === m._conditions.$where);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       var n = m.$where('x');
       assert.equal(m, n);
-    })
-  })
+    });
+  });
 
-  describe('where', function(){
-    it('without arguments', function(){
+  describe('where', function() {
+    it('without arguments', function() {
       var m = mquery();
       m.where();
       assert.deepEqual({}, m._conditions);
-    })
-    it('with non-string/object argument', function(){
+    });
+    it('with non-string/object argument', function() {
       var m = mquery();
 
-      assert.throws(function(){
+      assert.throws(function() {
         m.where([]);
       }, /path must be a string or object/);
-    })
-    describe('with one argument', function(){
-      it('that is an object', function(){
+    });
+    describe('with one argument', function() {
+      it('that is an object', function() {
         var m = mquery();
         m.where({ name: 'flawed' });
         assert.strictEqual(m._conditions.name, 'flawed');
-      })
-      it('that is a query', function(){
+      });
+      it('that is a query', function() {
         var m = mquery({ name: 'first' });
         var n = mquery({ name: 'changed' });
         m.where(n);
         assert.strictEqual(m._conditions.name, 'changed');
-      })
-      it('that is a string', function(){
+      });
+      it('that is a string', function() {
         var m = mquery();
         m.where('name');
         assert.equal('name', m._path);
         assert.strictEqual(m._conditions.name, undefined);
-      })
-    })
-    it('with two arguments', function(){
+      });
+    });
+    it('with two arguments', function() {
       var m = mquery();
       m.where('name', 'The Great Pumpkin');
       assert.equal('name', m._path);
       assert.strictEqual(m._conditions.name, 'The Great Pumpkin');
-    })
-    it('is chainable', function(){
-      var m = mquery();
-      var n = m.where('x', 'y');
+    });
+    it('is chainable', function() {
+      var m = mquery(),
+          n;
+
+      n = m.where('x', 'y');
       assert.equal(m, n);
-      var n = m.where()
+      n = m.where();
       assert.equal(m, n);
-    })
-  })
-  describe('equals', function(){
-    it('must be called after where()', function(){
+    });
+  });
+  describe('equals', function() {
+    it('must be called after where()', function() {
       var m = mquery();
-      assert.throws(function () {
+      assert.throws(function() {
         m.equals();
-      }, /must be used after where/)
-    })
-    it('sets value of path set with where()', function(){
+      }, /must be used after where/);
+    });
+    it('sets value of path set with where()', function() {
       var m = mquery();
       m.where('age').equals(1000);
       assert.deepEqual({ age: 1000 }, m._conditions);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       var n = m.where('x').equals(3);
       assert.equal(m, n);
-    })
-  })
-  describe('eq', function(){
-    it('is alias of equals', function(){
+    });
+  });
+  describe('eq', function() {
+    it('is alias of equals', function() {
       var m = mquery();
       m.where('age').eq(1000);
       assert.deepEqual({ age: 1000 }, m._conditions);
-    })
-  })
-  describe('or', function(){
-    it('pushes onto the internal $or condition', function(){
+    });
+  });
+  describe('or', function() {
+    it('pushes onto the internal $or condition', function() {
       var m = mquery();
       m.or({ 'Nightmare Before Christmas': true });
-      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$or)
-    })
-    it('allows passing arrays', function(){
+      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$or);
+    });
+    it('allows passing arrays', function() {
       var m = mquery();
       var arg = [{ 'Nightmare Before Christmas': true }, { x: 1 }];
       m.or(arg);
-      assert.deepEqual(arg, m._conditions.$or)
-    })
-    it('allows calling multiple times', function(){
+      assert.deepEqual(arg, m._conditions.$or);
+    });
+    it('allows calling multiple times', function() {
       var m = mquery();
       var arg = [{ looper: true }, { x: 1 }];
       m.or(arg);
-      m.or({ y: 1 })
-      m.or([{ w: 'oo' }, { z: 'oo'} ])
-      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$or)
-    })
-    it('is chainable', function(){
+      m.or({ y: 1 });
+      m.or([{ w: 'oo' }, { z: 'oo'} ]);
+      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$or);
+    });
+    it('is chainable', function() {
       var m = mquery();
-      m.or({ o: "k"}).where('name', 'table');
-      assert.deepEqual({ name: 'table', $or: [{ o: 'k' }] }, m._conditions)
-    })
-  })
+      m.or({ o: 'k'}).where('name', 'table');
+      assert.deepEqual({ name: 'table', $or: [{ o: 'k' }] }, m._conditions);
+    });
+  });
 
-  describe('nor', function(){
-    it('pushes onto the internal $nor condition', function(){
+  describe('nor', function() {
+    it('pushes onto the internal $nor condition', function() {
       var m = mquery();
       m.nor({ 'Nightmare Before Christmas': true });
-      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$nor)
-    })
-    it('allows passing arrays', function(){
+      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$nor);
+    });
+    it('allows passing arrays', function() {
       var m = mquery();
       var arg = [{ 'Nightmare Before Christmas': true }, { x: 1 }];
       m.nor(arg);
-      assert.deepEqual(arg, m._conditions.$nor)
-    })
-    it('allows calling multiple times', function(){
+      assert.deepEqual(arg, m._conditions.$nor);
+    });
+    it('allows calling multiple times', function() {
       var m = mquery();
       var arg = [{ looper: true }, { x: 1 }];
       m.nor(arg);
-      m.nor({ y: 1 })
-      m.nor([{ w: 'oo' }, { z: 'oo'} ])
-      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$nor)
-    })
-    it('is chainable', function(){
+      m.nor({ y: 1 });
+      m.nor([{ w: 'oo' }, { z: 'oo'} ]);
+      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$nor);
+    });
+    it('is chainable', function() {
       var m = mquery();
-      m.nor({ o: "k"}).where('name', 'table');
-      assert.deepEqual({ name: 'table', $nor: [{ o: 'k' }] }, m._conditions)
-    })
-  })
+      m.nor({ o: 'k'}).where('name', 'table');
+      assert.deepEqual({ name: 'table', $nor: [{ o: 'k' }] }, m._conditions);
+    });
+  });
 
-  describe('and', function(){
-    it('pushes onto the internal $and condition', function(){
+  describe('and', function() {
+    it('pushes onto the internal $and condition', function() {
       var m = mquery();
       m.and({ 'Nightmare Before Christmas': true });
-      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$and)
-    })
-    it('allows passing arrays', function(){
+      assert.deepEqual([{'Nightmare Before Christmas': true }], m._conditions.$and);
+    });
+    it('allows passing arrays', function() {
       var m = mquery();
       var arg = [{ 'Nightmare Before Christmas': true }, { x: 1 }];
       m.and(arg);
-      assert.deepEqual(arg, m._conditions.$and)
-    })
-    it('allows calling multiple times', function(){
+      assert.deepEqual(arg, m._conditions.$and);
+    });
+    it('allows calling multiple times', function() {
       var m = mquery();
       var arg = [{ looper: true }, { x: 1 }];
       m.and(arg);
-      m.and({ y: 1 })
-      m.and([{ w: 'oo' }, { z: 'oo'} ])
-      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$and)
-    })
-    it('is chainable', function(){
+      m.and({ y: 1 });
+      m.and([{ w: 'oo' }, { z: 'oo'} ]);
+      assert.deepEqual([{looper:true},{x:1},{y:1},{w:'oo'},{z:'oo'}], m._conditions.$and);
+    });
+    it('is chainable', function() {
       var m = mquery();
-      m.and({ o: "k"}).where('name', 'table');
-      assert.deepEqual({ name: 'table', $and: [{ o: 'k' }] }, m._conditions)
-    })
-  })
+      m.and({ o: 'k'}).where('name', 'table');
+      assert.deepEqual({ name: 'table', $and: [{ o: 'k' }] }, m._conditions);
+    });
+  });
 
-  function generalCondition (type) {
-    return function () {
-      it('accepts 2 args', function(){
+  function generalCondition(type) {
+    return function() {
+      it('accepts 2 args', function() {
         var m = mquery()[type]('count', 3);
         var check = {};
         check['$' + type] = 3;
         assert.deepEqual(m._conditions.count, check);
-      })
-      it('uses previously set `where` path if 1 arg passed', function(){
+      });
+      it('uses previously set `where` path if 1 arg passed', function() {
         var m = mquery().where('count')[type](3);
         var check = {};
         check['$' + type] = 3;
         assert.deepEqual(m._conditions.count, check);
-      })
-      it('throws if 1 arg was passed but no previous `where` was used', function(){
-        assert.throws(function(){
+      });
+      it('throws if 1 arg was passed but no previous `where` was used', function() {
+        assert.throws(function() {
           mquery()[type](3);
         }, /must be used after where/);
-      })
-      it('is chainable', function(){
+      });
+      it('is chainable', function() {
         var m = mquery().where('count')[type](3).where('x', 8);
         var check = {x: 8, count: {}};
         check.count['$' + type] = 3;
         assert.deepEqual(m._conditions, check);
-      })
-      it('overwrites previous value', function(){
+      });
+      it('overwrites previous value', function() {
         var m = mquery().where('count')[type](3)[type](8);
         var check = {};
         check['$' + type] = 8;
         assert.deepEqual(m._conditions.count, check);
-      })
-    }
+      });
+    };
   }
 
-  'gt gte lt lte ne in nin regex size maxDistance minDistance'.split(' ').forEach(function (type) {
-    describe(type, generalCondition(type))
-  })
+  'gt gte lt lte ne in nin regex size maxDistance minDistance'.split(' ').forEach(function(type) {
+    describe(type, generalCondition(type));
+  });
 
-  describe('mod', function () {
-    describe('with 1 argument', function(){
-      it('requires a previous where()', function(){
-        assert.throws(function () {
-          mquery().mod([30, 10])
+  describe('mod', function() {
+    describe('with 1 argument', function() {
+      it('requires a previous where()', function() {
+        assert.throws(function() {
+          mquery().mod([30, 10]);
         }, /must be used after where/);
-      })
-      it('works', function(){
+      });
+      it('works', function() {
         var m = mquery().where('madmen').mod([10,20]);
-        assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }})
-      })
-    })
+        assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }});
+      });
+    });
 
-    describe('with 2 arguments and second is non-Array', function(){
-      it('requires a previous where()', function(){
-        assert.throws(function () {
-          mquery().mod('x', 10)
+    describe('with 2 arguments and second is non-Array', function() {
+      it('requires a previous where()', function() {
+        assert.throws(function() {
+          mquery().mod('x', 10);
         }, /must be used after where/);
-      })
-      it('works', function(){
+      });
+      it('works', function() {
         var m = mquery().where('madmen').mod(10, 20);
-        assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }})
-      })
-    })
+        assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }});
+      });
+    });
 
-    it('with 2 arguments and second is an array', function(){
+    it('with 2 arguments and second is an array', function() {
       var m = mquery().mod('madmen', [10,20]);
-      assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }})
-    })
+      assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }});
+    });
 
-    it('with 3 arguments', function(){
+    it('with 3 arguments', function() {
       var m = mquery().mod('madmen', 10, 20);
-      assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }})
-    })
+      assert.deepEqual(m._conditions, { madmen: { $mod: [10,20] }});
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery().mod('madmen', 10, 20).where('x', 8);
       var check = { madmen: { $mod: [10,20] }, x: 8};
       assert.deepEqual(m._conditions, check);
-    })
-  })
+    });
+  });
 
-  describe('exists', function(){
-    it('with 0 args', function(){
-      it('throws if not used after where()', function(){
-        assert.throws(function () {
-          mquery().exists()
+  describe('exists', function() {
+    it('with 0 args', function() {
+      it('throws if not used after where()', function() {
+        assert.throws(function() {
+          mquery().exists();
         }, /must be used after where/);
-      })
-      it('works', function(){
+      });
+      it('works', function() {
         var m = mquery().where('name').exists();
         var check = { name: { $exists: true }};
         assert.deepEqual(m._conditions, check);
-      })
-    })
+      });
+    });
 
-    describe('with 1 arg', function(){
-      describe('that is boolean', function(){
-        it('throws if not used after where()', function(){
-          assert.throws(function () {
-            mquery().exists()
+    describe('with 1 arg', function() {
+      describe('that is boolean', function() {
+        it('throws if not used after where()', function() {
+          assert.throws(function() {
+            mquery().exists();
           }, /must be used after where/);
-        })
-        it('works', function(){
+        });
+        it('works', function() {
           var m = mquery().exists('name', false);
           var check = { name: { $exists: false }};
           assert.deepEqual(m._conditions, check);
-        })
-      })
-      describe('that is not boolean', function(){
-        it('sets the value to `true`', function(){
+        });
+      });
+      describe('that is not boolean', function() {
+        it('sets the value to `true`', function() {
           var m = mquery().where('name').exists('yummy');
           var check = { yummy: { $exists: true }};
           assert.deepEqual(m._conditions, check);
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('with 2 args', function(){
-      it('works', function(){
+    describe('with 2 args', function() {
+      it('works', function() {
         var m = mquery().exists('yummy', false);
         var check = { yummy: { $exists: false }};
         assert.deepEqual(m._conditions, check);
-      })
-    })
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery().where('name').exists().find({ x: 1 });
       var check = { name: { $exists: true }, x: 1};
       assert.deepEqual(m._conditions, check);
-    })
-  })
+    });
+  });
 
-  describe('elemMatch', function(){
-    describe('with null/undefined first argument', function(){
-      assert.throws(function () {
+  describe('elemMatch', function() {
+    describe('with null/undefined first argument', function() {
+      assert.throws(function() {
         mquery().elemMatch();
       }, /Invalid argument/);
-      assert.throws(function () {
+      assert.throws(function() {
         mquery().elemMatch(null);
       }, /Invalid argument/);
-      assert.doesNotThrow(function () {
+      assert.doesNotThrow(function() {
         mquery().elemMatch('', {});
       });
-    })
+    });
 
-    describe('with 1 argument', function(){
-      it('throws if not a function or object', function(){
-        assert.throws(function () {
+    describe('with 1 argument', function() {
+      it('throws if not a function or object', function() {
+        assert.throws(function() {
           mquery().elemMatch([]);
         }, /Invalid argument/);
-      })
+      });
 
-      describe('that is an object', function(){
-        it('throws if no previous `where` was used', function(){
-          assert.throws(function () {
+      describe('that is an object', function() {
+        it('throws if no previous `where` was used', function() {
+          assert.throws(function() {
             mquery().elemMatch({});
           }, /must be used after where/);
-        })
-        it('works', function(){
+        });
+        it('works', function() {
           var m = mquery().where('comment').elemMatch({ author: 'joe', votes: {$gte: 3 }});
           assert.deepEqual({ comment: { $elemMatch: { author: 'joe', votes: {$gte: 3}}}}, m._conditions);
-        })
-      })
-      describe('that is a function', function(){
-        it('throws if no previous `where` was used', function(){
-          assert.throws(function () {
-            mquery().elemMatch(function(){});
+        });
+      });
+      describe('that is a function', function() {
+        it('throws if no previous `where` was used', function() {
+          assert.throws(function() {
+            mquery().elemMatch(function() {});
           }, /must be used after where/);
-        })
-        it('works', function(){
-          var m = mquery().where('comment').elemMatch(function (query) {
-            query.where({ author: 'joe', votes: {$gte: 3 }})
+        });
+        it('works', function() {
+          var m = mquery().where('comment').elemMatch(function(query) {
+            query.where({ author: 'joe', votes: {$gte: 3 }});
           });
           assert.deepEqual({ comment: { $elemMatch: { author: 'joe', votes: {$gte: 3}}}}, m._conditions);
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('with 2 arguments', function(){
-      describe('and the 2nd is an object', function(){
-        it('works', function(){
+    describe('with 2 arguments', function() {
+      describe('and the 2nd is an object', function() {
+        it('works', function() {
           var m = mquery().elemMatch('comment', { author: 'joe', votes: {$gte: 3 }});
           assert.deepEqual({ comment: { $elemMatch: { author: 'joe', votes: {$gte: 3}}}}, m._conditions);
-        })
-      })
-      describe('and the 2nd is a function', function(){
-        it('works', function(){
-          var m = mquery().elemMatch('comment', function (query) {
-            query.where({ author: 'joe', votes: {$gte: 3 }})
+        });
+      });
+      describe('and the 2nd is a function', function() {
+        it('works', function() {
+          var m = mquery().elemMatch('comment', function(query) {
+            query.where({ author: 'joe', votes: {$gte: 3 }});
           });
           assert.deepEqual({ comment: { $elemMatch: { author: 'joe', votes: {$gte: 3}}}}, m._conditions);
-        })
-      })
-      it('and the 2nd is not a function or object', function(){
-        assert.throws(function () {
+        });
+      });
+      it('and the 2nd is not a function or object', function() {
+        assert.throws(function() {
           mquery().elemMatch('comment', []);
         }, /Invalid argument/);
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('within', function(){
-    it('is chainable', function(){
+  describe('within', function() {
+    it('is chainable', function() {
       var m = mquery();
       assert.equal(m.where('a').within(), m);
-    })
-    describe('when called with arguments', function(){
-      it('must follow where()', function(){
-        assert.throws(function () {
+    });
+    describe('when called with arguments', function() {
+      it('must follow where()', function() {
+        assert.throws(function() {
           mquery().within([]);
         }, /must be used after where/);
-      })
+      });
 
-      describe('of length 1', function(){
-        it('throws if not a recognized shape', function(){
-          assert.throws(function () {
+      describe('of length 1', function() {
+        it('throws if not a recognized shape', function() {
+          assert.throws(function() {
             mquery().where('loc').within({});
-          }, /Invalid argument/)
-          assert.throws(function () {
+          }, /Invalid argument/);
+          assert.throws(function() {
             mquery().where('loc').within(null);
-          }, /Invalid argument/)
-        })
-        it('delegates to circle when center exists', function(){
+          }, /Invalid argument/);
+        });
+        it('delegates to circle when center exists', function() {
           var m = mquery().where('loc').within({ center: [10,10], radius: 3 });
           assert.deepEqual({ $geoWithin: {$center:[[10,10], 3]}}, m._conditions.loc);
-        })
-        it('delegates to box when exists', function(){
+        });
+        it('delegates to box when exists', function() {
           var m = mquery().where('loc').within({ box: [[10,10], [11,14]] });
           assert.deepEqual({ $geoWithin: {$box:[[10,10], [11,14]]}}, m._conditions.loc);
-        })
-        it('delegates to polygon when exists', function(){
+        });
+        it('delegates to polygon when exists', function() {
           var m = mquery().where('loc').within({ polygon: [[10,10], [11,14],[10,9]] });
           assert.deepEqual({ $geoWithin: {$polygon:[[10,10], [11,14],[10,9]]}}, m._conditions.loc);
-        })
-        it('delegates to geometry when exists', function(){
+        });
+        it('delegates to geometry when exists', function() {
           var m = mquery().where('loc').within({ type: 'Polygon', coordinates: [[10,10], [11,14],[10,9]] });
           assert.deepEqual({ $geoWithin: {$geometry: {type:'Polygon', coordinates: [[10,10], [11,14],[10,9]]}}}, m._conditions.loc);
-        })
-      })
+        });
+      });
 
-      describe('of length 2', function(){
-        it('delegates to box()', function(){
+      describe('of length 2', function() {
+        it('delegates to box()', function() {
           var m = mquery().where('loc').within([1,2],[2,5]);
           assert.deepEqual(m._conditions.loc, { $geoWithin: { $box: [[1,2],[2,5]]}});
-        })
-      })
+        });
+      });
 
-      describe('of length > 2', function(){
-        it('delegates to polygon()', function(){
+      describe('of length > 2', function() {
+        it('delegates to polygon()', function() {
           var m = mquery().where('loc').within([1,2],[2,5],[2,4],[1,3]);
           assert.deepEqual(m._conditions.loc, { $geoWithin: { $polygon: [[1,2],[2,5],[2,4],[1,3]]}});
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
-  describe('geoWithin', function(){
-    before(function(){
+  describe('geoWithin', function() {
+    before(function() {
       mquery.use$geoWithin = false;
-    })
-    after(function(){
+    });
+    after(function() {
       mquery.use$geoWithin = true;
-    })
-    describe('when called with arguments', function(){
-      describe('of length 1', function(){
-        it('delegates to circle when center exists', function(){
+    });
+    describe('when called with arguments', function() {
+      describe('of length 1', function() {
+        it('delegates to circle when center exists', function() {
           var m = mquery().where('loc').within({ center: [10,10], radius: 3 });
           assert.deepEqual({ $within: {$center:[[10,10], 3]}}, m._conditions.loc);
-        })
-        it('delegates to box when exists', function(){
+        });
+        it('delegates to box when exists', function() {
           var m = mquery().where('loc').within({ box: [[10,10], [11,14]] });
           assert.deepEqual({ $within: {$box:[[10,10], [11,14]]}}, m._conditions.loc);
-        })
-        it('delegates to polygon when exists', function(){
+        });
+        it('delegates to polygon when exists', function() {
           var m = mquery().where('loc').within({ polygon: [[10,10], [11,14],[10,9]] });
           assert.deepEqual({ $within: {$polygon:[[10,10], [11,14],[10,9]]}}, m._conditions.loc);
-        })
-        it('delegates to geometry when exists', function(){
+        });
+        it('delegates to geometry when exists', function() {
           var m = mquery().where('loc').within({ type: 'Polygon', coordinates: [[10,10], [11,14],[10,9]] });
           assert.deepEqual({ $within: {$geometry: {type:'Polygon', coordinates: [[10,10], [11,14],[10,9]]}}}, m._conditions.loc);
-        })
-      })
+        });
+      });
 
-      describe('of length 2', function(){
-        it('delegates to box()', function(){
+      describe('of length 2', function() {
+        it('delegates to box()', function() {
           var m = mquery().where('loc').within([1,2],[2,5]);
           assert.deepEqual(m._conditions.loc, { $within: { $box: [[1,2],[2,5]]}});
-        })
-      })
+        });
+      });
 
-      describe('of length > 2', function(){
-        it('delegates to polygon()', function(){
+      describe('of length > 2', function() {
+        it('delegates to polygon()', function() {
           var m = mquery().where('loc').within([1,2],[2,5],[2,4],[1,3]);
           assert.deepEqual(m._conditions.loc, { $within: { $polygon: [[1,2],[2,5],[2,4],[1,3]]}});
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
-  describe('box', function(){
-    describe('with 1 argument', function(){
-      it('throws', function(){
-        assert.throws(function () {
+  describe('box', function() {
+    describe('with 1 argument', function() {
+      it('throws', function() {
+        assert.throws(function() {
           mquery().box('sometihng');
         }, /Invalid argument/);
-      })
-    })
-    describe('with > 3 arguments', function(){
-      it('throws', function(){
-        assert.throws(function () {
+      });
+    });
+    describe('with > 3 arguments', function() {
+      it('throws', function() {
+        assert.throws(function() {
           mquery().box(1,2,3,4);
         }, /Invalid argument/);
-      })
-    })
+      });
+    });
 
-    describe('with 2 arguments', function(){
-      it('throws if not used after where()', function(){
-        assert.throws(function () {
+    describe('with 2 arguments', function() {
+      it('throws if not used after where()', function() {
+        assert.throws(function() {
           mquery().box([],[]);
         }, /must be used after where/);
-      })
-      it('works', function(){
+      });
+      it('works', function() {
         var m = mquery().where('loc').box([1,2],[3,4]);
         assert.deepEqual(m._conditions.loc, { $geoWithin: { $box: [[1,2],[3,4]] }});
-      })
-    })
+      });
+    });
 
-    describe('with 3 arguments', function(){
-      it('works', function(){
+    describe('with 3 arguments', function() {
+      it('works', function() {
         var m = mquery().box('loc', [1,2],[3,4]);
         assert.deepEqual(m._conditions.loc, { $geoWithin: { $box: [[1,2],[3,4]] }});
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('polygon', function(){
-    describe('when first argument is not a string', function(){
-      it('throws if not used after where()', function(){
-        assert.throws(function () {
+  describe('polygon', function() {
+    describe('when first argument is not a string', function() {
+      it('throws if not used after where()', function() {
+        assert.throws(function() {
           mquery().polygon({});
         }, /must be used after where/);
 
-        assert.doesNotThrow(function () {
+        assert.doesNotThrow(function() {
           mquery().where('loc').polygon([1,2], [2,3], [3,6]);
         });
-      })
+      });
 
-      it('assigns arguments to within polygon condition', function(){
+      it('assigns arguments to within polygon condition', function() {
         var m = mquery().where('loc').polygon([1,2], [2,3], [3,6]);
         assert.deepEqual(m._conditions, { loc: {$geoWithin: {$polygon: [[1,2],[2,3],[3,6]]}} });
-      })
-    })
+      });
+    });
 
-    describe('when first arg is a string', function(){
-      it('assigns remaining arguments to within polygon condition', function(){
+    describe('when first arg is a string', function() {
+      it('assigns remaining arguments to within polygon condition', function() {
         var m = mquery().polygon('loc', [1,2], [2,3], [3,6]);
         assert.deepEqual(m._conditions, { loc: {$geoWithin: {$polygon: [[1,2],[2,3],[3,6]]}} });
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('circle', function(){
-    describe('with one arg', function(){
-      it('must follow where()', function(){
-        assert.throws(function () {
+  describe('circle', function() {
+    describe('with one arg', function() {
+      it('must follow where()', function() {
+        assert.throws(function() {
           mquery().circle('x');
         }, /must be used after where/);
-        assert.doesNotThrow(function () {
+        assert.doesNotThrow(function() {
           mquery().where('loc').circle({center:[0,0], radius: 3 });
         });
-      })
-      it('works', function(){
+      });
+      it('works', function() {
         var m = mquery().where('loc').circle({center:[0,0], radius: 3 });
         assert.deepEqual(m._conditions, { loc: { $geoWithin: {$center: [[0,0],3] }}});
-      })
-    })
-    describe('with 3 args', function(){
-      it('throws', function(){
-        assert.throws(function () {
+      });
+    });
+    describe('with 3 args', function() {
+      it('throws', function() {
+        assert.throws(function() {
           mquery().where('loc').circle(1,2,3);
         }, /Invalid argument/);
-      })
-    })
-    describe('requires radius and center', function(){
-      assert.throws(function () {
+      });
+    });
+    describe('requires radius and center', function() {
+      assert.throws(function() {
         mquery().circle('loc', { center: 1 });
       }, /center and radius are required/);
-      assert.throws(function () {
+      assert.throws(function() {
         mquery().circle('loc', { radius: 1 });
       }, /center and radius are required/);
-      assert.doesNotThrow(function () {
+      assert.doesNotThrow(function() {
         mquery().circle('loc', { center: [1,2], radius: 1 });
       });
-    })
-  })
+    });
+  });
 
-  describe('geometry', function(){
+  describe('geometry', function() {
     // within + intersects
     var point = { type: 'Point', coordinates: [[0,0],[1,1]] };
 
-    it('must be called after within or intersects', function(done){
-      assert.throws(function () {
+    it('must be called after within or intersects', function(done) {
+      assert.throws(function() {
         mquery().where('a').geometry(point);
       }, /must come after/);
 
-      assert.doesNotThrow(function () {
+      assert.doesNotThrow(function() {
         mquery().where('a').within().geometry(point);
       });
 
-      assert.doesNotThrow(function () {
+      assert.doesNotThrow(function() {
         mquery().where('a').intersects().geometry(point);
       });
 
       done();
-    })
+    });
 
-    describe('when called with one argument', function(){
-      describe('after within()', function(){
-        it('and arg quacks like geoJSON', function(done){
+    describe('when called with one argument', function() {
+      describe('after within()', function() {
+        it('and arg quacks like geoJSON', function(done) {
           var m = mquery().where('a').within().geometry(point);
           assert.deepEqual({ a: { $geoWithin: { $geometry: point }}}, m._conditions);
           done();
-        })
-      })
+        });
+      });
 
-      describe('after intersects()', function(){
-        it('and arg quacks like geoJSON', function(done){
+      describe('after intersects()', function() {
+        it('and arg quacks like geoJSON', function(done) {
           var m = mquery().where('a').intersects().geometry(point);
           assert.deepEqual({ a: { $geoIntersects: { $geometry: point }}}, m._conditions);
           done();
-        })
-      })
+        });
+      });
 
-      it('and arg does not quack like geoJSON', function(done){
-        assert.throws(function () {
+      it('and arg does not quack like geoJSON', function(done) {
+        assert.throws(function() {
           mquery().where('b').within().geometry({type:1, coordinates:2});
         }, /Invalid argument/);
         done();
-      })
-    })
+      });
+    });
 
-    describe('when called with zero arguments', function(){
-      it('throws', function(done){
-        assert.throws(function () {
+    describe('when called with zero arguments', function() {
+      it('throws', function(done) {
+        assert.throws(function() {
           mquery().where('a').within().geometry();
         }, /Invalid argument/);
 
         done();
-      })
-    })
+      });
+    });
 
-    describe('when called with more than one arguments', function(){
-      it('throws', function(done){
-        assert.throws(function () {
+    describe('when called with more than one arguments', function() {
+      it('throws', function(done) {
+        assert.throws(function() {
           mquery().where('a').within().geometry({type:'a',coordinates:[]}, 2);
         }, /Invalid argument/);
         done();
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('intersects', function(){
-    it('must be used after where()', function(done){
+  describe('intersects', function() {
+    it('must be used after where()', function(done) {
       var m = mquery();
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects();
-      }, /must be used after where/)
+      }, /must be used after where/);
       done();
-    })
+    });
 
-    it('sets geo comparison to "$intersects"', function(done){
+    it('sets geo comparison to "$intersects"', function(done) {
       var n = mquery().where('a').intersects();
       assert.equal('$geoIntersects', n._geoComparison);
       done();
-    })
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery();
       assert.equal(m.where('a').intersects(), m);
-    })
+    });
 
-    it('calls geometry if argument quacks like geojson', function(done){
+    it('calls geometry if argument quacks like geojson', function(done) {
       var m = mquery();
       var o = { type: 'LineString', coordinates: [[0,1],[3,40]] };
       var ran = false;
 
-      m.geometry = function (arg) {
+      m.geometry = function(arg) {
         ran = true;
         assert.deepEqual(o, arg);
-      }
+      };
 
       m.where('a').intersects(o);
       assert.ok(ran);
 
       done();
-    })
+    });
 
-    it('throws if argument is not geometry-like', function(done){
+    it('throws if argument is not geometry-like', function(done) {
       var m = mquery().where('a');
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects(null);
       }, /Invalid argument/);
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects(undefined);
       }, /Invalid argument/);
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects(false);
       }, /Invalid argument/);
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects({});
       }, /Invalid argument/);
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects([]);
       }, /Invalid argument/);
 
-      assert.throws(function () {
-        m.intersects(function(){});
+      assert.throws(function() {
+        m.intersects(function() {});
       }, /Invalid argument/);
 
-      assert.throws(function () {
+      assert.throws(function() {
         m.intersects(NaN);
       }, /Invalid argument/);
 
       done();
-    })
-  })
+    });
+  });
 
-  describe('near', function(){
+  describe('near', function() {
     // near nearSphere
-    describe('with 0 args', function(){
-      it('is compatible with geometry()', function(done){
+    describe('with 0 args', function() {
+      it('is compatible with geometry()', function(done) {
         var q = mquery().where('x').near().geometry({ type: 'Point', coordinates: [180, 11] });
         assert.deepEqual({ $near: {$geometry: {type:'Point', coordinates: [180,11]}}}, q._conditions.x);
         done();
-      })
-    })
+      });
+    });
 
-    describe('with 1 arg', function(){
-      it('throws if not used after where()', function(){
-        assert.throws(function () {
+    describe('with 1 arg', function() {
+      it('throws if not used after where()', function() {
+        assert.throws(function() {
           mquery().near(1);
-        }, /must be used after where/)
-      })
-      it('does not throw if used after where()', function(){
-        assert.doesNotThrow(function () {
+        }, /must be used after where/);
+      });
+      it('does not throw if used after where()', function() {
+        assert.doesNotThrow(function() {
           mquery().where('loc').near({center:[1,1]});
-        })
-      })
-    })
-    describe('with > 2 args', function(){
-      it('throws', function(){
-        assert.throws(function () {
+        });
+      });
+    });
+    describe('with > 2 args', function() {
+      it('throws', function() {
+        assert.throws(function() {
           mquery().near(1,2,3);
-        }, /Invalid argument/)
-      })
-    })
+        }, /Invalid argument/);
+      });
+    });
 
-    it('creates $geometry args for GeoJSON', function(){
+    it('creates $geometry args for GeoJSON', function() {
       var m = mquery().where('loc').near({ center: { type: 'Point', coordinates: [10,10] }});
       assert.deepEqual({ $near: {$geometry: {type:'Point', coordinates: [10,10]}}}, m._conditions.loc);
-    })
+    });
 
-    it('expects `center`', function(){
-      assert.throws(function () {
+    it('expects `center`', function() {
+      assert.throws(function() {
         mquery().near('loc', { maxDistance: 3 });
-      }, /center is required/)
-      assert.doesNotThrow(function () {
+      }, /center is required/);
+      assert.doesNotThrow(function() {
         mquery().near('loc', { center: [3,4] });
-      })
-    })
+      });
+    });
 
-    it('accepts spherical conditions', function(){
+    it('accepts spherical conditions', function() {
       var m = mquery().where('loc').near({ center: [1,2], spherical: true });
       assert.deepEqual(m._conditions, { loc: { $nearSphere: [1,2]}});
-    })
+    });
 
-    it('is non-spherical by default', function(){
+    it('is non-spherical by default', function() {
       var m = mquery().where('loc').near({ center: [1,2] });
       assert.deepEqual(m._conditions, { loc: { $near: [1,2]}});
-    })
+    });
 
-    it('supports maxDistance', function(){
+    it('supports maxDistance', function() {
       var m = mquery().where('loc').near({ center: [1,2], maxDistance:4 });
       assert.deepEqual(m._conditions, { loc: { $near: [1,2], $maxDistance: 4}});
-    })
+    });
 
-    it('supports minDistance', function(){
+    it('supports minDistance', function() {
       var m = mquery().where('loc').near({ center: [1,2], minDistance:4 });
       assert.deepEqual(m._conditions, { loc: { $near: [1,2], $minDistance: 4}});
-    })
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery().where('loc').near({ center: [1,2], maxDistance:4 }).find({ x: 1 });
       assert.deepEqual(m._conditions, { loc: { $near: [1,2], $maxDistance: 4}, x: 1});
-    })
+    });
 
-    describe('supports passing GeoJSON, gh-13', function(){
-      it('with center', function(){
+    describe('supports passing GeoJSON, gh-13', function() {
+      it('with center', function() {
         var m = mquery().where('loc').near({
-            center: { type: 'Point', coordinates: [1,1] }
-          , maxDistance: 2
+          center: { type: 'Point', coordinates: [1,1] },
+          maxDistance: 2
         });
 
         var expect = {
-            loc: {
-                $near: {
-                    $geometry: {
-                        type: 'Point'
-                      , coordinates : [1,1]
-                    }
-                  , $maxDistance : 2
-                }
+          loc: {
+            $near: {
+              $geometry: {
+                type: 'Point',
+                coordinates : [1,1]
+              },
+              $maxDistance : 2
             }
-        }
+          }
+        };
 
         assert.deepEqual(m._conditions, expect);
-      })
-    })
-  })
+      });
+    });
+  });
 
   // fields
 
-  describe('select', function(){
-    describe('with 0 args', function(){
-      it('is chainable', function(){
-        var m = mquery()
+  describe('select', function() {
+    describe('with 0 args', function() {
+      it('is chainable', function() {
+        var m = mquery();
         assert.equal(m, m.select());
-      })
-    })
+      });
+    });
 
-    it('accepts an object', function(){
-      var o = { x: 1, y: 1 }
+    it('accepts an object', function() {
+      var o = { x: 1, y: 1 };
       var m = mquery().select(o);
       assert.deepEqual(m._fields, o);
-    })
+    });
 
-    it('accepts a string', function(){
+    it('accepts a string', function() {
       var o = 'x -y';
       var m = mquery().select(o);
       assert.deepEqual(m._fields, { x: 1, y: 0 });
-    })
+    });
 
-    it('does accept an array', function(){
+    it('does accept an array', function() {
       var o = ['x', '-y'];
       var m = mquery().select(o);
       assert.deepEqual(m._fields, { x: 1, y: 0 });
-    })
+    });
 
-    it('merges previous arguments', function(){
-      var o = { x: 1, y: 0, a: 1 }
+    it('merges previous arguments', function() {
+      var o = { x: 1, y: 0, a: 1 };
       var m = mquery().select(o);
-      m.select('z -u w').select({ x: 0 })
+      m.select('z -u w').select({ x: 0 });
       assert.deepEqual(m._fields, {
-          x: 0
-        , y: 0
-        , z: 1
-        , u: 0
-        , w: 1
-        , a: 1
+        x: 0,
+        y: 0,
+        z: 1,
+        u: 0,
+        w: 1,
+        a: 1
       });
-    })
+    });
 
-    it('rejects non-string, object, arrays', function(){
-      assert.throws(function () {
-        mquery().select(function(){});
+    it('rejects non-string, object, arrays', function() {
+      assert.throws(function() {
+        mquery().select(function() {});
       }, /Invalid select\(\) argument/);
-    })
+    });
 
-    it('accepts arguments objects', function(){
+    it('accepts arguments objects', function() {
       var m = mquery();
-      function t () {
+      function t() {
         m.select(arguments);
         assert.deepEqual(m._fields, { x: 1, y: 0 });
       }
       t('x', '-y');
-    })
+    });
 
     noDistinct('select');
-  })
+  });
 
   describe('selected', function() {
     it('returns true when fields have been selected', function(done) {
-      var m = mquery().select({ name: 1 });
+      var m;
+
+      m = mquery().select({ name: 1 });
       assert.ok(m.selected());
 
-      var m = mquery().select('name');
+      m = mquery().select('name');
       assert.ok(m.selected());
 
       done();
@@ -984,7 +993,7 @@ describe('mquery', function(){
   });
 
   describe('selectedInclusively', function() {
-    describe('returns false', function(){
+    describe('returns false', function() {
       it('when no fields have been selected', function(done) {
         assert.strictEqual(false, mquery().selectedInclusively());
         assert.equal(false, mquery().select({}).selectedInclusively());
@@ -1013,7 +1022,7 @@ describe('mquery', function(){
   });
 
   describe('selectedExclusively', function() {
-    describe('returns false', function(){
+    describe('returns false', function() {
       it('when no fields have been selected', function(done) {
         assert.equal(false, mquery().selectedExclusively());
         assert.equal(false, mquery().select({}).selectedExclusively());
@@ -1038,90 +1047,90 @@ describe('mquery', function(){
     });
   });
 
-  describe('slice', function(){
-    describe('with 0 args', function(){
-      it('is chainable', function(){
-        var m = mquery()
+  describe('slice', function() {
+    describe('with 0 args', function() {
+      it('is chainable', function() {
+        var m = mquery();
         assert.equal(m, m.slice());
-      })
-      it('is a noop', function(){
+      });
+      it('is a noop', function() {
         var m = mquery().slice();
         assert.deepEqual(m._fields, undefined);
-      })
-    })
+      });
+    });
 
-    describe('with 1 arg', function(){
-      it('throws if not called after where()', function(){
-        assert.throws(function () {
+    describe('with 1 arg', function() {
+      it('throws if not called after where()', function() {
+        assert.throws(function() {
           mquery().slice(1);
         }, /must be used after where/);
-        assert.doesNotThrow(function () {
+        assert.doesNotThrow(function() {
           mquery().where('a').slice(1);
         });
-      })
-      it('that is a number', function(){
+      });
+      it('that is a number', function() {
         var query = mquery();
         query.where('collection').slice(5);
         assert.deepEqual(query._fields, {collection: {$slice: 5}});
-      })
-      it('that is an array', function(){
+      });
+      it('that is an array', function() {
         var query = mquery();
         query.where('collection').slice([5,10]);
         assert.deepEqual(query._fields, {collection: {$slice: [5,10]}});
-      })
+      });
       it('that is an object', function() {
         var query = mquery();
         query.slice({ collection: [5, 10] });
         assert.deepEqual(query._fields, {collection: {$slice: [5,10]}});
-      })
-    })
+      });
+    });
 
-    describe('with 2 args', function(){
-      describe('and first is a number', function(){
-        it('throws if not called after where', function(){
-          assert.throws(function () {
+    describe('with 2 args', function() {
+      describe('and first is a number', function() {
+        it('throws if not called after where', function() {
+          assert.throws(function() {
             mquery().slice(2,3);
           }, /must be used after where/);
-        })
-        it('does not throw if used after where', function(){
+        });
+        it('does not throw if used after where', function() {
           var query = mquery();
           query.where('collection').slice(2,3);
           assert.deepEqual(query._fields, {collection: {$slice: [2,3]}});
-        })
-      })
-      it('and first is not a number', function(){
+        });
+      });
+      it('and first is not a number', function() {
         var query = mquery().slice('collection', [-5, 2]);
         assert.deepEqual(query._fields, {collection: {$slice: [-5,2]}});
-      })
-    })
+      });
+    });
 
-    describe('with 3 args', function(){
-      it('works', function(){
+    describe('with 3 args', function() {
+      it('works', function() {
         var query = mquery();
         query.slice('collection', 14, 10);
         assert.deepEqual(query._fields, {collection: {$slice: [14, 10]}});
-      })
-    })
+      });
+    });
 
     noDistinct('slice');
     no('count', 'slice');
-  })
+  });
 
   // options
 
-  describe('sort', function(){
-    describe('with 0 args', function(){
-      it('chains', function(){
+  describe('sort', function() {
+    describe('with 0 args', function() {
+      it('chains', function() {
         var m = mquery();
         assert.equal(m, m.sort());
-      })
-      it('has no affect', function(){
+      });
+      it('has no affect', function() {
         var m = mquery();
         assert.equal(m.options.sort, undefined);
-      })
+      });
     });
 
-    it('works', function(){
+    it('works', function() {
       var query = mquery();
       query.sort('a -c b');
       assert.deepEqual(query.options.sort, { a : 1, b: 1, c : -1});
@@ -1142,7 +1151,7 @@ describe('mquery', function(){
         e = err;
       }
       assert.ok(e, 'uh oh. no error was thrown');
-      assert.equal(e.message, "Invalid sort() argument, must be array of arrays")
+      assert.equal(e.message, 'Invalid sort() argument, must be array of arrays');
 
       query = mquery();
       e = undefined;
@@ -1156,19 +1165,19 @@ describe('mquery', function(){
       assert.equal(e.message, 'Invalid sort() argument. Must be a string, object, or array.');
     });
 
-    it('handles $meta sort options', function(){
+    it('handles $meta sort options', function() {
       var query = mquery();
-      query.sort({ score: { $meta : "textScore" } });
-      assert.deepEqual(query.options.sort, { score : { $meta : "textScore" } });
+      query.sort({ score: { $meta : 'textScore' } });
+      assert.deepEqual(query.options.sort, { score : { $meta : 'textScore' } });
     });
 
-    it('array syntax', function(){
+    it('array syntax', function() {
       var query = mquery();
       query.sort([['field', 1], ['test', -1]]);
       assert.deepEqual(query.options.sort, [['field', 1], ['test', -1]]);
     });
 
-    it('throws with mixed array/object syntax', function(){
+    it('throws with mixed array/object syntax', function() {
       var query = mquery();
       assert.throws(function() {
         query.sort({ field: 1 }).sort([['test', -1]]);
@@ -1186,79 +1195,81 @@ describe('mquery', function(){
       query.sort(new Map().set('field', 1).set('test', -1));
       assert.deepEqual(query.options.sort, new Map().set('field', 1).set('test', -1));
     });
-  })
+  });
 
-  function simpleOption (type, options) {
-    describe(type, function(){
-      it('sets the ' + type + ' option', function(){
+  function simpleOption(type, options) {
+    describe(type, function() {
+      it('sets the ' + type + ' option', function() {
         var m = mquery()[type](2);
         var optionName = options.name || type;
         assert.equal(2, m.options[optionName]);
-      })
-      it('is chainable', function(){
+      });
+      it('is chainable', function() {
         var m = mquery();
         assert.equal(m[type](3), m);
-      })
+      });
 
       if (!options.distinct) noDistinct(type);
       if (!options.count) no('count', type);
-    })
+    });
   }
 
   var negated = {
-      limit: {distinct: false, count: true}
-    , skip: {distinct: false, count: true}
-    , maxScan: {distinct: false, count: false}
-    , batchSize: {distinct: false, count: false}
-    , maxTime: {distinct: true, count: true, name: 'maxTimeMS' }
-    , comment: {distinct: false, count: false}
+    limit: {distinct: false, count: true},
+    skip: {distinct: false, count: true},
+    maxScan: {distinct: false, count: false},
+    batchSize: {distinct: false, count: false},
+    maxTime: {distinct: true, count: true, name: 'maxTimeMS' },
+    comment: {distinct: false, count: false}
   };
-  Object.keys(negated).forEach(function (key) {
+  Object.keys(negated).forEach(function(key) {
     simpleOption(key, negated[key]);
-  })
+  });
 
-  describe('snapshot', function(){
-    it('works', function(){
-      var query = mquery();
+  describe('snapshot', function() {
+    it('works', function() {
+      var query;
+
+      query = mquery();
       query.snapshot();
       assert.equal(true, query.options.snapshot);
 
-      var query = mquery()
+      query = mquery();
       query.snapshot(true);
       assert.equal(true, query.options.snapshot);
 
-      var query = mquery()
+      query = mquery();
       query.snapshot(false);
       assert.equal(false, query.options.snapshot);
-    })
+    });
     noDistinct('snapshot');
     no('count', 'snapshot');
-  })
+  });
 
-  describe('hint', function(){
-    it('accepts an object', function(){
+  describe('hint', function() {
+    it('accepts an object', function() {
       var query2 = mquery();
       query2.hint({'a': 1, 'b': -1});
       assert.deepEqual(query2.options.hint, {'a': 1, 'b': -1});
-    })
+    });
 
-    it('accepts a string', function(){
+    it('accepts a string', function() {
       var query2 = mquery();
       query2.hint('a');
       assert.deepEqual(query2.options.hint, 'a');
-    })
+    });
 
-    it('rejects everything else', function(){
-      assert.throws(function(){
+    it('rejects everything else', function() {
+      assert.throws(function() {
         mquery().hint(['c']);
       }, /Invalid hint./);
-      assert.throws(function(){
+      assert.throws(function() {
         mquery().hint(1);
       }, /Invalid hint./);
-    })
+    });
 
-    describe('does not have side affects', function(){
-      it('on invalid arg', function(){
+    describe('does not have side affects', function() {
+      it('on invalid arg', function() {
         var m = mquery();
         try {
           m.hint(1);
@@ -1266,171 +1277,175 @@ describe('mquery', function(){
           // ignore
         }
         assert.equal(undefined, m.options.hint);
-      })
-      it('on missing arg', function(){
+      });
+      it('on missing arg', function() {
         var m = mquery().hint();
         assert.equal(undefined, m.options.hint);
-      })
-    })
+      });
+    });
 
     noDistinct('hint');
-  })
+  });
 
-  describe('slaveOk', function(){
-    it('works', function(){
-      var query = mquery();
+  describe('slaveOk', function() {
+    it('works', function() {
+      var query;
+
+      query = mquery();
       query.slaveOk();
       assert.equal(true, query.options.slaveOk);
 
-      var query = mquery()
+      query = mquery();
       query.slaveOk(true);
       assert.equal(true, query.options.slaveOk);
 
-      var query = mquery()
+      query = mquery();
       query.slaveOk(false);
       assert.equal(false, query.options.slaveOk);
-    })
-  })
+    });
+  });
 
-  describe('read', function(){
-    it('sets associated readPreference option', function(){
+  describe('read', function() {
+    it('sets associated readPreference option', function() {
       var m = mquery();
       m.read('p');
       assert.equal('primary', m.options.readPreference);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       assert.equal(m, m.read('sp'));
-    })
-  })
+    });
+  });
 
-  describe('readConcern', function(){
-    it('sets associated readConcern option', function(){
+  describe('readConcern', function() {
+    it('sets associated readConcern option', function() {
       var m = mquery();
       m.readConcern('s');
       assert.deepEqual({ level: 'snapshot' }, m.options.readConcern);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       assert.equal(m, m.readConcern('lz'));
-    })
-  })
+    });
+  });
 
-  describe('tailable', function(){
-    it('works', function(){
-      var query = mquery();
+  describe('tailable', function() {
+    it('works', function() {
+      var query;
+
+      query = mquery();
       query.tailable();
       assert.equal(true, query.options.tailable);
 
-      var query = mquery()
+      query = mquery();
       query.tailable(true);
       assert.equal(true, query.options.tailable);
 
-      var query = mquery()
+      query = mquery();
       query.tailable(false);
       assert.equal(false, query.options.tailable);
-    })
-    it('is chainable', function(){
+    });
+    it('is chainable', function() {
       var m = mquery();
       assert.equal(m, m.tailable());
-    })
+    });
     noDistinct('tailable');
     no('count', 'tailable');
-  })
+  });
 
   // query utilities
 
-  describe('merge', function(){
-    describe('with falsy arg', function(){
-      it('returns itself', function(){
+  describe('merge', function() {
+    describe('with falsy arg', function() {
+      it('returns itself', function() {
         var m = mquery();
         assert.equal(m, m.merge());
         assert.equal(m, m.merge(null));
         assert.equal(m, m.merge(0));
-      })
-    })
-    describe('with an argument', function(){
-      describe('that is not a query or plain object', function(){
-        it('throws', function(){
-          assert.throws(function () {
+      });
+    });
+    describe('with an argument', function() {
+      describe('that is not a query or plain object', function() {
+        it('throws', function() {
+          assert.throws(function() {
             mquery().merge([]);
           }, /Invalid argument/);
-          assert.throws(function () {
+          assert.throws(function() {
             mquery().merge('merge');
           }, /Invalid argument/);
-          assert.doesNotThrow(function () {
+          assert.doesNotThrow(function() {
             mquery().merge({});
           }, /Invalid argument/);
-        })
-      })
+        });
+      });
 
-      describe('that is a query', function(){
-        it('merges conditions, field selection, and options', function(){
-          var m = mquery({ x: 'hi' }, { select: 'x y', another: true })
+      describe('that is a query', function() {
+        it('merges conditions, field selection, and options', function() {
+          var m = mquery({ x: 'hi' }, { select: 'x y', another: true });
           var n = mquery().merge(m);
           assert.deepEqual(n._conditions, m._conditions);
           assert.deepEqual(n._fields, m._fields);
           assert.deepEqual(n.options, m.options);
-        })
-        it('clones update arguments', function(done){
-          var original = { $set: { iTerm: true }}
+        });
+        it('clones update arguments', function(done) {
+          var original = { $set: { iTerm: true }};
           var m = mquery().update(original);
           var n = mquery().merge(m);
-          m.update({ $set: { x: 2 }})
+          m.update({ $set: { x: 2 }});
           assert.notDeepEqual(m._update, n._update);
           done();
-        })
-        it('is chainable', function(){
+        });
+        it('is chainable', function() {
           var m = mquery({ x: 'hi' });
           var n = mquery();
           assert.equal(n, n.merge(m));
-        })
-      })
+        });
+      });
 
-      describe('that is an object', function(){
-        it('merges', function(){
+      describe('that is an object', function() {
+        it('merges', function() {
           var m = { x: 'hi' };
           var n = mquery().merge(m);
           assert.deepEqual(n._conditions, { x: 'hi' });
-        })
-        it('clones update arguments', function(done){
-          var original = { $set: { iTerm: true }}
+        });
+        it('clones update arguments', function(done) {
+          var original = { $set: { iTerm: true }};
           var m = mquery().update(original);
           var n = mquery().merge(original);
-          m.update({ $set: { x: 2 }})
+          m.update({ $set: { x: 2 }});
           assert.notDeepEqual(m._update, n._update);
           done();
-        })
-        it('is chainable', function(){
+        });
+        it('is chainable', function() {
           var m = { x: 'hi' };
           var n = mquery();
           assert.equal(n, n.merge(m));
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
   // queries
 
-  describe('find', function(){
-    describe('with no callback', function(){
-      it('does not execute', function(){
+  describe('find', function() {
+    describe('with no callback', function() {
+      it('does not execute', function() {
         var m = mquery();
-        assert.doesNotThrow(function () {
-          m.find()
-        })
-        assert.doesNotThrow(function () {
-          m.find({ x: 1 })
-        })
-      })
-    })
+        assert.doesNotThrow(function() {
+          m.find();
+        });
+        assert.doesNotThrow(function() {
+          m.find({ x: 1 });
+        });
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery().find({ x: 1 }).find().find({ y: 2 });
       assert.deepEqual(m._conditions, {x:1,y:2});
-    })
+    });
 
-    it('merges other queries', function(){
+    it('merges other queries', function() {
       var m = mquery({ name: 'mquery' });
       m.tailable();
       m.select('_id');
@@ -1438,64 +1453,64 @@ describe('mquery', function(){
       assert.deepEqual(a._conditions, m._conditions);
       assert.deepEqual(a.options, m.options);
       assert.deepEqual(a._fields, m._fields);
-    })
+    });
 
-    describe('executes', function(){
-      before(function (done) {
+    describe('executes', function() {
+      before(function(done) {
         col.insert({ name: 'mquery' }, { safe: true }, done);
       });
 
-      after(function(done){
+      after(function(done) {
         col.remove({ name: 'mquery' }, done);
-      })
+      });
 
-      it('when criteria is passed with a callback', function(done){
-        mquery(col).find({ name: 'mquery' }, function (err, docs) {
-          assert.ifError(err);
-          assert.equal(1, docs.length);
-          done();
-        })
-      })
-      it('when Query is passed with a callback', function(done){
-        var m = mquery({ name: 'mquery' });
-        mquery(col).find(m, function (err, docs) {
-          assert.ifError(err);
-          assert.equal(1, docs.length);
-          done();
-        })
-      })
-      it('when just a callback is passed', function(done){
-        mquery({ name: 'mquery' }).collection(col).find(function (err, docs) {
+      it('when criteria is passed with a callback', function(done) {
+        mquery(col).find({ name: 'mquery' }, function(err, docs) {
           assert.ifError(err);
           assert.equal(1, docs.length);
           done();
         });
-      })
-    })
-  })
+      });
+      it('when Query is passed with a callback', function(done) {
+        var m = mquery({ name: 'mquery' });
+        mquery(col).find(m, function(err, docs) {
+          assert.ifError(err);
+          assert.equal(1, docs.length);
+          done();
+        });
+      });
+      it('when just a callback is passed', function(done) {
+        mquery({ name: 'mquery' }).collection(col).find(function(err, docs) {
+          assert.ifError(err);
+          assert.equal(1, docs.length);
+          done();
+        });
+      });
+    });
+  });
 
-  describe('findOne', function(){
-    describe('with no callback', function(){
-      it('does not execute', function(){
+  describe('findOne', function() {
+    describe('with no callback', function() {
+      it('does not execute', function() {
         var m = mquery();
-        assert.doesNotThrow(function () {
-          m.findOne()
-        })
-        assert.doesNotThrow(function () {
-          m.findOne({ x: 1 })
-        })
-      })
-    })
+        assert.doesNotThrow(function() {
+          m.findOne();
+        });
+        assert.doesNotThrow(function() {
+          m.findOne({ x: 1 });
+        });
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery();
       var n = m.findOne({ x: 1 }).findOne().findOne({ y: 2 });
       assert.equal(m, n);
       assert.deepEqual(m._conditions, {x:1,y:2});
       assert.equal('findOne', m.op);
-    })
+    });
 
-    it('merges other queries', function(){
+    it('merges other queries', function() {
       var m = mquery({ name: 'mquery' });
       m.read('nearest');
       m.select('_id');
@@ -1503,67 +1518,67 @@ describe('mquery', function(){
       assert.deepEqual(a._conditions, m._conditions);
       assert.deepEqual(a.options, m.options);
       assert.deepEqual(a._fields, m._fields);
-    })
+    });
 
-    describe('executes', function(){
-      before(function (done) {
+    describe('executes', function() {
+      before(function(done) {
         col.insert({ name: 'mquery findone' }, { safe: true }, done);
       });
 
-      after(function(done){
+      after(function(done) {
         col.remove({ name: 'mquery findone' }, done);
-      })
+      });
 
-      it('when criteria is passed with a callback', function(done){
-        mquery(col).findOne({ name: 'mquery findone' }, function (err, doc) {
-          assert.ifError(err);
-          assert.ok(doc);
-          assert.equal('mquery findone', doc.name);
-          done();
-        })
-      })
-      it('when Query is passed with a callback', function(done){
-        var m = mquery(col).where({ name: 'mquery findone' });
-        mquery(col).findOne(m, function (err, doc) {
-          assert.ifError(err);
-          assert.ok(doc);
-          assert.equal('mquery findone', doc.name);
-          done();
-        })
-      })
-      it('when just a callback is passed', function(done){
-        mquery({ name: 'mquery findone' }).collection(col).findOne(function (err, doc) {
+      it('when criteria is passed with a callback', function(done) {
+        mquery(col).findOne({ name: 'mquery findone' }, function(err, doc) {
           assert.ifError(err);
           assert.ok(doc);
           assert.equal('mquery findone', doc.name);
           done();
         });
-      })
-    })
-  })
+      });
+      it('when Query is passed with a callback', function(done) {
+        var m = mquery(col).where({ name: 'mquery findone' });
+        mquery(col).findOne(m, function(err, doc) {
+          assert.ifError(err);
+          assert.ok(doc);
+          assert.equal('mquery findone', doc.name);
+          done();
+        });
+      });
+      it('when just a callback is passed', function(done) {
+        mquery({ name: 'mquery findone' }).collection(col).findOne(function(err, doc) {
+          assert.ifError(err);
+          assert.ok(doc);
+          assert.equal('mquery findone', doc.name);
+          done();
+        });
+      });
+    });
+  });
 
-  describe('count', function(){
-    describe('with no callback', function(){
-      it('does not execute', function(){
+  describe('count', function() {
+    describe('with no callback', function() {
+      it('does not execute', function() {
         var m = mquery();
-        assert.doesNotThrow(function () {
-          m.count()
-        })
-        assert.doesNotThrow(function () {
-          m.count({ x: 1 })
-        })
-      })
-    })
+        assert.doesNotThrow(function() {
+          m.count();
+        });
+        assert.doesNotThrow(function() {
+          m.count({ x: 1 });
+        });
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery();
       var n = m.count({ x: 1 }).count().count({ y: 2 });
       assert.equal(m, n);
       assert.deepEqual(m._conditions, {x:1,y:2});
       assert.equal('count', m.op);
-    })
+    });
 
-    it('merges other queries', function(){
+    it('merges other queries', function() {
       var m = mquery({ name: 'mquery' });
       m.read('nearest');
       m.select('_id');
@@ -1571,136 +1586,136 @@ describe('mquery', function(){
       assert.deepEqual(a._conditions, m._conditions);
       assert.deepEqual(a.options, m.options);
       assert.deepEqual(a._fields, m._fields);
-    })
+    });
 
-    describe('executes', function(){
-      before(function (done) {
+    describe('executes', function() {
+      before(function(done) {
         col.insert({ name: 'mquery count' }, { safe: true }, done);
       });
 
-      after(function(done){
+      after(function(done) {
         col.remove({ name: 'mquery count' }, done);
-      })
+      });
 
-      it('when criteria is passed with a callback', function(done){
-        mquery(col).count({ name: 'mquery count' }, function (err, count) {
+      it('when criteria is passed with a callback', function(done) {
+        mquery(col).count({ name: 'mquery count' }, function(err, count) {
           assert.ifError(err);
           assert.ok(count);
           assert.ok(1 === count);
           done();
-        })
-      })
-      it('when Query is passed with a callback', function(done){
+        });
+      });
+      it('when Query is passed with a callback', function(done) {
         var m = mquery({ name: 'mquery count' });
-        mquery(col).count(m, function (err, count) {
+        mquery(col).count(m, function(err, count) {
           assert.ifError(err);
           assert.ok(count);
           assert.ok(1 === count);
           done();
-        })
-      })
-      it('when just a callback is passed', function(done){
-        mquery({ name: 'mquery count' }).collection(col).count(function (err, count) {
+        });
+      });
+      it('when just a callback is passed', function(done) {
+        mquery({ name: 'mquery count' }).collection(col).count(function(err, count) {
           assert.ifError(err);
           assert.ok(1 === count);
           done();
         });
-      })
-    })
+      });
+    });
 
-    describe('validates its option', function(){
-      it('sort', function(done){
-        assert.doesNotThrow(function(){
-          var m = mquery().sort('x').count();
+    describe('validates its option', function() {
+      it('sort', function(done) {
+        assert.doesNotThrow(function() {
+          mquery().sort('x').count();
         });
         done();
-      })
+      });
 
-      it('select', function(done){
-        assert.throws(function(){
-          var m = mquery().select('x').count();
+      it('select', function(done) {
+        assert.throws(function() {
+          mquery().select('x').count();
         }, /field selection and slice cannot be used with count/);
         done();
-      })
+      });
 
-      it('slice', function(done){
-        assert.throws(function(){
-          var m = mquery().where('x').slice(-3).count();
+      it('slice', function(done) {
+        assert.throws(function() {
+          mquery().where('x').slice(-3).count();
         }, /field selection and slice cannot be used with count/);
         done();
-      })
+      });
 
-      it('limit', function(done){
-        assert.doesNotThrow(function(){
-          var m = mquery().limit(3).count();
-        })
+      it('limit', function(done) {
+        assert.doesNotThrow(function() {
+          mquery().limit(3).count();
+        });
         done();
-      })
+      });
 
-      it('skip', function(done){
-        assert.doesNotThrow(function(){
-          var m = mquery().skip(3).count();
-        })
+      it('skip', function(done) {
+        assert.doesNotThrow(function() {
+          mquery().skip(3).count();
+        });
         done();
-      })
+      });
 
-      it('batchSize', function(done){
-        assert.throws(function(){
-          var m = mquery({}, { batchSize: 3 }).count();
+      it('batchSize', function(done) {
+        assert.throws(function() {
+          mquery({}, { batchSize: 3 }).count();
         }, /batchSize cannot be used with count/);
         done();
-      })
+      });
 
-      it('comment', function(done){
-        assert.throws(function(){
-          var m = mquery().comment('mquery').count();
+      it('comment', function(done) {
+        assert.throws(function() {
+          mquery().comment('mquery').count();
         }, /comment cannot be used with count/);
         done();
-      })
+      });
 
-      it('maxScan', function(done){
-        assert.throws(function(){
-          var m = mquery().maxScan(300).count();
+      it('maxScan', function(done) {
+        assert.throws(function() {
+          mquery().maxScan(300).count();
         }, /maxScan cannot be used with count/);
         done();
-      })
+      });
 
-      it('snapshot', function(done){
-        assert.throws(function(){
-          var m = mquery().snapshot().count();
+      it('snapshot', function(done) {
+        assert.throws(function() {
+          mquery().snapshot().count();
         }, /snapshot cannot be used with count/);
         done();
-      })
+      });
 
-      it('tailable', function(done){
-        assert.throws(function(){
-          var m = mquery().tailable().count();
+      it('tailable', function(done) {
+        assert.throws(function() {
+          mquery().tailable().count();
         }, /tailable cannot be used with count/);
         done();
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('distinct', function(){
-    describe('with no callback', function(){
-      it('does not execute', function(){
+  describe('distinct', function() {
+    describe('with no callback', function() {
+      it('does not execute', function() {
         var m = mquery();
-        assert.doesNotThrow(function () {
-          m.distinct()
-        })
-        assert.doesNotThrow(function () {
-          m.distinct('name')
-        })
-        assert.doesNotThrow(function () {
-          m.distinct({ name: 'mquery distinct' })
-        })
-        assert.doesNotThrow(function () {
-          m.distinct({ name: 'mquery distinct' }, 'name')
-        })
-      })
-    })
+        assert.doesNotThrow(function() {
+          m.distinct();
+        });
+        assert.doesNotThrow(function() {
+          m.distinct('name');
+        });
+        assert.doesNotThrow(function() {
+          m.distinct({ name: 'mquery distinct' });
+        });
+        assert.doesNotThrow(function() {
+          m.distinct({ name: 'mquery distinct' }, 'name');
+        });
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery({x:1}).distinct('name');
       var n = m.distinct({y:2});
       assert.equal(m, n);
@@ -1709,190 +1724,190 @@ describe('mquery', function(){
       assert.equal('distinct', n.op);
     });
 
-    it('overwrites field', function(){
+    it('overwrites field', function() {
       var m = mquery({ name: 'mquery' }).distinct('name');
       m.distinct('rename');
       assert.equal(m._distinct, 'rename');
       m.distinct({x:1}, 'renamed');
       assert.equal(m._distinct, 'renamed');
-    })
+    });
 
-    it('merges other queries', function(){
-      var m = mquery().distinct({ name: 'mquery' }, 'age')
+    it('merges other queries', function() {
+      var m = mquery().distinct({ name: 'mquery' }, 'age');
       m.read('nearest');
       var a = mquery().distinct(m);
       assert.deepEqual(a._conditions, m._conditions);
       assert.deepEqual(a.options, m.options);
       assert.deepEqual(a._fields, m._fields);
       assert.deepEqual(a._distinct, m._distinct);
-    })
+    });
 
-    describe('executes', function(){
-      before(function (done) {
+    describe('executes', function() {
+      before(function(done) {
         col.insert({ name: 'mquery distinct', age: 1 }, { safe: true }, done);
       });
 
-      after(function(done){
+      after(function(done) {
         col.remove({ name: 'mquery distinct' }, done);
-      })
+      });
 
-      it('when distinct arg is passed with a callback', function(done){
-        mquery(col).distinct('distinct', function (err, doc) {
+      it('when distinct arg is passed with a callback', function(done) {
+        mquery(col).distinct('distinct', function(err, doc) {
           assert.ifError(err);
           assert.ok(doc);
           done();
-        })
-      })
-      describe('when criteria is passed with a callback', function(){
-        it('if distinct arg was declared', function(done){
-          mquery(col).distinct('age').distinct({ name: 'mquery distinct' }, function (err, doc) {
-            assert.ifError(err);
-            assert.ok(doc);
-            done();
-          })
-        })
-        it('but not if distinct arg was not declared', function(){
-          assert.throws(function(){
-            mquery(col).distinct({ name: 'mquery distinct' }, function(){})
-          }, /No value for `distinct`/)
-        })
-      })
-      describe('when Query is passed with a callback', function(){
-        var m = mquery({ name: 'mquery distinct' });
-        it('if distinct arg was declared', function(done){
-          mquery(col).distinct('age').distinct(m, function (err, doc) {
-            assert.ifError(err);
-            assert.ok(doc);
-            done();
-          })
-        })
-        it('but not if distinct arg was not declared', function(){
-          assert.throws(function(){
-            mquery(col).distinct(m, function(){})
-          }, /No value for `distinct`/)
-        })
-      })
-      describe('when just a callback is passed', function(done){
-        it('if distinct arg was declared', function(done){
-          var m = mquery({ name: 'mquery distinct' });
-          m.collection(col);
-          m.distinct('age');
-          m.distinct(function (err, doc) {
+        });
+      });
+      describe('when criteria is passed with a callback', function() {
+        it('if distinct arg was declared', function(done) {
+          mquery(col).distinct('age').distinct({ name: 'mquery distinct' }, function(err, doc) {
             assert.ifError(err);
             assert.ok(doc);
             done();
           });
-        })
-        it('but not if no distinct arg was declared', function(){
+        });
+        it('but not if distinct arg was not declared', function() {
+          assert.throws(function() {
+            mquery(col).distinct({ name: 'mquery distinct' }, function() {});
+          }, /No value for `distinct`/);
+        });
+      });
+      describe('when Query is passed with a callback', function() {
+        var m = mquery({ name: 'mquery distinct' });
+        it('if distinct arg was declared', function(done) {
+          mquery(col).distinct('age').distinct(m, function(err, doc) {
+            assert.ifError(err);
+            assert.ok(doc);
+            done();
+          });
+        });
+        it('but not if distinct arg was not declared', function() {
+          assert.throws(function() {
+            mquery(col).distinct(m, function() {});
+          }, /No value for `distinct`/);
+        });
+      });
+      describe('when just a callback is passed', function() {
+        it('if distinct arg was declared', function(done) {
+          var m = mquery({ name: 'mquery distinct' });
+          m.collection(col);
+          m.distinct('age');
+          m.distinct(function(err, doc) {
+            assert.ifError(err);
+            assert.ok(doc);
+            done();
+          });
+        });
+        it('but not if no distinct arg was declared', function() {
           var m = mquery();
           m.collection(col);
-          assert.throws(function () {
-            m.distinct(function(){});
+          assert.throws(function() {
+            m.distinct(function() {});
           }, /No value for `distinct`/);
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('validates its option', function(){
-      it('sort', function(done){
-        assert.throws(function(){
-          var m = mquery().sort('x').distinct();
+    describe('validates its option', function() {
+      it('sort', function(done) {
+        assert.throws(function() {
+          mquery().sort('x').distinct();
         }, /sort cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('select', function(done){
-        assert.throws(function(){
-          var m = mquery().select('x').distinct();
+      it('select', function(done) {
+        assert.throws(function() {
+          mquery().select('x').distinct();
         }, /field selection and slice cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('slice', function(done){
-        assert.throws(function(){
-          var m = mquery().where('x').slice(-3).distinct();
+      it('slice', function(done) {
+        assert.throws(function() {
+          mquery().where('x').slice(-3).distinct();
         }, /field selection and slice cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('limit', function(done){
-        assert.throws(function(){
-          var m = mquery().limit(3).distinct();
+      it('limit', function(done) {
+        assert.throws(function() {
+          mquery().limit(3).distinct();
         }, /limit cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('skip', function(done){
-        assert.throws(function(){
-          var m = mquery().skip(3).distinct();
+      it('skip', function(done) {
+        assert.throws(function() {
+          mquery().skip(3).distinct();
         }, /skip cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('batchSize', function(done){
-        assert.throws(function(){
-          var m = mquery({}, { batchSize: 3 }).distinct();
+      it('batchSize', function(done) {
+        assert.throws(function() {
+          mquery({}, { batchSize: 3 }).distinct();
         }, /batchSize cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('comment', function(done){
-        assert.throws(function(){
-          var m = mquery().comment('mquery').distinct();
+      it('comment', function(done) {
+        assert.throws(function() {
+          mquery().comment('mquery').distinct();
         }, /comment cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('maxScan', function(done){
-        assert.throws(function(){
-          var m = mquery().maxScan(300).distinct();
+      it('maxScan', function(done) {
+        assert.throws(function() {
+          mquery().maxScan(300).distinct();
         }, /maxScan cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('snapshot', function(done){
-        assert.throws(function(){
-          var m = mquery().snapshot().distinct();
+      it('snapshot', function(done) {
+        assert.throws(function() {
+          mquery().snapshot().distinct();
         }, /snapshot cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('hint', function(done){
-        assert.throws(function(){
-          var m = mquery().hint({ x: 1 }).distinct();
+      it('hint', function(done) {
+        assert.throws(function() {
+          mquery().hint({ x: 1 }).distinct();
         }, /hint cannot be used with distinct/);
         done();
-      })
+      });
 
-      it('tailable', function(done){
-        assert.throws(function(){
-          var m = mquery().tailable().distinct();
+      it('tailable', function(done) {
+        assert.throws(function() {
+          mquery().tailable().distinct();
         }, /tailable cannot be used with distinct/);
         done();
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('update', function(){
-    describe('with no callback', function(){
-      it('does not execute', function(){
+  describe('update', function() {
+    describe('with no callback', function() {
+      it('does not execute', function() {
         var m = mquery();
-        assert.doesNotThrow(function () {
-          m.update({ name: 'old' }, { name: 'updated' }, { multi: true })
-        })
-        assert.doesNotThrow(function () {
-          m.update({ name: 'old' }, { name: 'updated' })
-        })
-        assert.doesNotThrow(function () {
-          m.update({ name: 'updated' })
-        })
-        assert.doesNotThrow(function () {
-          m.update()
-        })
-      })
-    })
+        assert.doesNotThrow(function() {
+          m.update({ name: 'old' }, { name: 'updated' }, { multi: true });
+        });
+        assert.doesNotThrow(function() {
+          m.update({ name: 'old' }, { name: 'updated' });
+        });
+        assert.doesNotThrow(function() {
+          m.update({ name: 'updated' });
+        });
+        assert.doesNotThrow(function() {
+          m.update();
+        });
+      });
+    });
 
-    it('is chainable', function(){
+    it('is chainable', function() {
       var m = mquery({x:1}).update({ y: 2 });
       var n = m.where({y:2});
       assert.equal(m, n);
@@ -1901,7 +1916,7 @@ describe('mquery', function(){
       assert.equal('update', n.op);
     });
 
-    it('merges update doc arg', function(){
+    it('merges update doc arg', function() {
       var a = [1,2];
       var m = mquery().where({ name: 'mquery' }).update({ x: 'stuff', a: a });
       m.update({ z: 'stuff' });
@@ -1914,685 +1929,679 @@ describe('mquery', function(){
       assert.deepEqual(m._update, { z: 'renamed', x: 'stuff', a: a });
       a.push(3);
       assert.notDeepEqual(m._update, { z: 'renamed', x: 'stuff', a: a });
-    })
+    });
 
-    it('merges other options', function(){
+    it('merges other options', function() {
       var m = mquery();
       m.setOptions({ overwrite: true });
-      m.update({ age: 77 }, { name: 'pagemill' }, { multi: true })
+      m.update({ age: 77 }, { name: 'pagemill' }, { multi: true });
       assert.deepEqual({ age: 77 }, m._conditions);
       assert.deepEqual({ name: 'pagemill' }, m._update);
       assert.deepEqual({ overwrite: true, multi: true }, m.options);
-    })
+    });
 
-    describe('executes', function(){
+    describe('executes', function() {
       var id;
-      before(function (done) {
-        col.insert({ name: 'mquery update', age: 1 }, { safe: true }, function (err, res) {
+      before(function(done) {
+        col.insert({ name: 'mquery update', age: 1 }, { safe: true }, function(err, res) {
           id = res.insertedIds[0];
           done();
         });
       });
 
-      after(function(done){
+      after(function(done) {
         col.remove({ _id: id }, done);
-      })
+      });
 
-      describe('when conds + doc + opts + callback passed', function(){
-        it('works', function(done){
-          var m = mquery(col).where({ _id: id })
-          m.update({}, { name: 'Sparky' }, { safe: true }, function (err, res) {
+      describe('when conds + doc + opts + callback passed', function() {
+        it('works', function(done) {
+          var m = mquery(col).where({ _id: id });
+          m.update({}, { name: 'Sparky' }, { safe: true }, function(err, res) {
             assert.ifError(err);
             assert.equal(res.result.n, 1);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.name, 'Sparky');
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('when conds + doc + callback passed', function(){
-        it('works', function (done) {
-          var m = mquery(col).update({ _id: id }, { name: 'fairgrounds' }, function (err, num, doc) {
+      describe('when conds + doc + callback passed', function() {
+        it('works', function(done) {
+          var m = mquery(col).update({ _id: id }, { name: 'fairgrounds' }, function(err, num) {
             assert.ifError(err);
             assert.ok(1, num);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.name, 'fairgrounds');
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('when doc + callback passed', function(){
-        it('works', function (done) {
-          var m = mquery(col).where({ _id: id }).update({ name: 'changed' }, function (err, num, doc) {
+      describe('when doc + callback passed', function() {
+        it('works', function(done) {
+          var m = mquery(col).where({ _id: id }).update({ name: 'changed' }, function(err, num) {
             assert.ifError(err);
             assert.ok(1, num);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.name, 'changed');
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('when just callback passed', function(){
-        it('works', function (done) {
+      describe('when just callback passed', function() {
+        it('works', function(done) {
           var m = mquery(col).where({ _id: id });
           m.setOptions({ safe: true });
           m.update({ name: 'Frankenweenie' });
-          m.update(function (err, res) {
+          m.update(function(err, res) {
             assert.ifError(err);
             assert.equal(res.result.n, 1);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(doc.name, 'Frankenweenie');
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('without a callback', function(){
-        it('when forced by exec()', function(done){
+      describe('without a callback', function() {
+        it('when forced by exec()', function(done) {
           var m = mquery(col).where({ _id: id });
           m.setOptions({ safe: true, multi: true });
           m.update({ name: 'forced' });
 
           var update = m._collection.update;
-          m._collection.update = function (conds, doc, opts, cb) {
+          m._collection.update = function(conds, doc, opts) {
             m._collection.update = update;
 
             assert.ok(opts.safe);
             assert.ok(true === opts.multi);
             assert.equal('forced', doc.$set.name);
             done();
-          }
+          };
 
-          m.exec()
-        })
-      })
+          m.exec();
+        });
+      });
 
-      describe('except when update doc is empty and missing overwrite flag', function(){
-        it('works', function (done) {
+      describe('except when update doc is empty and missing overwrite flag', function() {
+        it('works', function(done) {
           var m = mquery(col).where({ _id: id });
           m.setOptions({ safe: true });
-          m.update({ }, function (err, num) {
+          m.update({ }, function(err, num) {
             assert.ifError(err);
             assert.ok(0 === num);
-            setTimeout(function(){
-              m.findOne(function (err, doc) {
+            setTimeout(function() {
+              m.findOne(function(err, doc) {
                 assert.ifError(err);
                 assert.equal(3, mquery.utils.keys(doc).length);
                 assert.equal(id, doc._id.toString());
                 assert.equal('Frankenweenie', doc.name);
                 done();
-              })
+              });
             }, 300);
-          })
-        })
+          });
+        });
       });
 
-      describe('when update doc is set with overwrite flag', function(){
-        it('works', function (done) {
+      describe('when update doc is set with overwrite flag', function() {
+        it('works', function(done) {
           var m = mquery(col).where({ _id: id });
           m.setOptions({ safe: true, overwrite: true });
-          m.update({ all: 'yep', two: 2 }, function (err, res) {
+          m.update({ all: 'yep', two: 2 }, function(err, res) {
             assert.ifError(err);
             assert.equal(res.result.n, 1);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(3, mquery.utils.keys(doc).length);
               assert.equal('yep', doc.all);
               assert.equal(2, doc.two);
               assert.equal(id, doc._id.toString());
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('when update doc is empty with overwrite flag', function(){
-        it('works', function (done) {
+      describe('when update doc is empty with overwrite flag', function() {
+        it('works', function(done) {
           var m = mquery(col).where({ _id: id });
           m.setOptions({ safe: true, overwrite: true });
-          m.update({ }, function (err, res) {
+          m.update({ }, function(err, res) {
             assert.ifError(err);
             assert.equal(res.result.n, 1);
-            m.findOne(function (err, doc) {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.equal(1, mquery.utils.keys(doc).length);
               assert.equal(id, doc._id.toString());
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('when boolean (true) - exec()', function(){
-        it('works', function(done){
+      describe('when boolean (true) - exec()', function() {
+        it('works', function(done) {
           var m = mquery(col).where({ _id: id });
           m.update({ name: 'bool' }).update(true);
-          setTimeout(function () {
-            m.findOne(function (err, doc) {
+          setTimeout(function() {
+            m.findOne(function(err, doc) {
               assert.ifError(err);
               assert.ok(doc);
               assert.equal('bool', doc.name);
               done();
-            })
-          }, 300)
-        })
-      })
-    })
-  })
+            });
+          }, 300);
+        });
+      });
+    });
+  });
 
-  describe('remove', function(){
-    describe('with 0 args', function(){
-      var name = 'remove: no args test'
-      before(function(done){
-        col.insert({ name: name }, { safe: true }, done)
-      })
-      after(function(done){
-        col.remove({ name: name }, { safe: true }, done)
-      })
+  describe('remove', function() {
+    describe('with 0 args', function() {
+      var name = 'remove: no args test';
+      before(function(done) {
+        col.insert({ name: name }, { safe: true }, done);
+      });
+      after(function(done) {
+        col.remove({ name: name }, { safe: true }, done);
+      });
 
-      it('does not execute', function(done){
+      it('does not execute', function(done) {
         var remove = col.remove;
-        col.remove = function () {
+        col.remove = function() {
           col.remove = remove;
           done(new Error('remove executed!'));
-        }
+        };
 
-        var m = mquery(col).where({ name: name }).remove()
-        setTimeout(function () {
+        mquery(col).where({ name: name }).remove();
+        setTimeout(function() {
           col.remove = remove;
           done();
         }, 10);
-      })
+      });
 
-      it('chains', function(){
+      it('chains', function() {
         var m = mquery();
         assert.equal(m, m.remove());
-      })
-    })
+      });
+    });
 
-    describe('with 1 argument', function(){
-      var name = 'remove: 1 arg test'
-      before(function(done){
-        col.insert({ name: name }, { safe: true }, done)
-      })
-      after(function(done){
-        col.remove({ name: name }, { safe: true }, done)
-      })
+    describe('with 1 argument', function() {
+      var name = 'remove: 1 arg test';
+      before(function(done) {
+        col.insert({ name: name }, { safe: true }, done);
+      });
+      after(function(done) {
+        col.remove({ name: name }, { safe: true }, done);
+      });
 
-      describe('that is a', function(){
-        it('plain object', function(){
+      describe('that is a', function() {
+        it('plain object', function() {
           var m = mquery(col).remove({ name: 'Whiskers' });
-          m.remove({ color: '#fff' })
+          m.remove({ color: '#fff' });
           assert.deepEqual({ name: 'Whiskers', color: '#fff' }, m._conditions);
-        })
+        });
 
-        it('query', function(){
+        it('query', function() {
           var q = mquery({ color: '#fff' });
           var m = mquery(col).remove({ name: 'Whiskers' });
-          m.remove(q)
+          m.remove(q);
           assert.deepEqual({ name: 'Whiskers', color: '#fff' }, m._conditions);
-        })
+        });
 
-        it('function', function(done){
-          mquery(col, { safe: true }).where({name: name}).remove(function (err) {
+        it('function', function(done) {
+          mquery(col, { safe: true }).where({name: name}).remove(function(err) {
             assert.ifError(err);
-            mquery(col).findOne({ name: name }, function (err, doc) {
+            mquery(col).findOne({ name: name }, function(err, doc) {
               assert.ifError(err);
               assert.equal(null, doc);
               done();
-            })
+            });
           });
-        })
+        });
 
-        it('boolean (true) - execute', function(done){
-          col.insert({ name: name }, { safe: true }, function (err) {
+        it('boolean (true) - execute', function(done) {
+          col.insert({ name: name }, { safe: true }, function(err) {
             assert.ifError(err);
-            mquery(col).findOne({ name: name }, function (err, doc) {
+            mquery(col).findOne({ name: name }, function(err, doc) {
               assert.ifError(err);
               assert.ok(doc);
               mquery(col).remove(true);
-              setTimeout(function () {
-                mquery(col).find(function (err, docs) {
+              setTimeout(function() {
+                mquery(col).find(function(err, docs) {
                   assert.ifError(err);
                   assert.ok(docs);
                   assert.equal(0, docs.length);
                   done();
-                })
-              }, 300)
-            })
-          })
-        })
-      })
-    })
+                });
+              }, 300);
+            });
+          });
+        });
+      });
+    });
 
-    describe('with 2 arguments', function(){
-      var name = 'remove: 2 arg test'
-      beforeEach(function(done){
-        col.remove({}, { safe: true }, function (err) {
+    describe('with 2 arguments', function() {
+      var name = 'remove: 2 arg test';
+      beforeEach(function(done) {
+        col.remove({}, { safe: true }, function(err) {
           assert.ifError(err);
-          col.insert([{ name: 'shelly' }, { name: name }], { safe: true }, function (err) {
+          col.insert([{ name: 'shelly' }, { name: name }], { safe: true }, function(err) {
             assert.ifError(err);
-            mquery(col).find(function (err, docs) {
+            mquery(col).find(function(err, docs) {
               assert.ifError(err);
               assert.equal(2, docs.length);
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
-      describe('plain object + callback', function(){
-        it('works', function(done){
-          mquery(col).remove({ name: name }, function (err) {
+      describe('plain object + callback', function() {
+        it('works', function(done) {
+          mquery(col).remove({ name: name }, function(err) {
             assert.ifError(err);
-            mquery(col).find(function (err, docs) {
+            mquery(col).find(function(err, docs) {
               assert.ifError(err);
               assert.ok(docs);
               assert.equal(1, docs.length);
               assert.equal('shelly', docs[0].name);
               done();
-            })
+            });
           });
-        })
-      })
+        });
+      });
 
-      describe('mquery + callback', function(){
-        it('works', function(done){
+      describe('mquery + callback', function() {
+        it('works', function(done) {
           var m = mquery({ name: name });
-          mquery(col).remove(m, function (err) {
+          mquery(col).remove(m, function(err) {
             assert.ifError(err);
-            mquery(col).find(function (err, docs) {
+            mquery(col).find(function(err, docs) {
               assert.ifError(err);
               assert.ok(docs);
               assert.equal(1, docs.length);
               assert.equal('shelly', docs[0].name);
               done();
-            })
+            });
           });
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
-  function validateFindAndModifyOptions (method) {
-    describe('validates its option', function(){
-      it('sort', function(done){
-        assert.doesNotThrow(function(){
-          var m = mquery().sort('x')[method]();
-        })
+  function validateFindAndModifyOptions(method) {
+    describe('validates its option', function() {
+      it('sort', function(done) {
+        assert.doesNotThrow(function() {
+          mquery().sort('x')[method]();
+        });
         done();
-      })
+      });
 
-      it('select', function(done){
-        assert.doesNotThrow(function(){
-          var m = mquery().select('x')[method]();
-        })
+      it('select', function(done) {
+        assert.doesNotThrow(function() {
+          mquery().select('x')[method]();
+        });
         done();
-      })
+      });
 
-      it('limit', function(done){
-        assert.throws(function(){
-          var m = mquery().limit(3)[method]();
+      it('limit', function(done) {
+        assert.throws(function() {
+          mquery().limit(3)[method]();
         }, new RegExp('limit cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('skip', function(done){
-        assert.throws(function(){
-          var m = mquery().skip(3)[method]();
+      it('skip', function(done) {
+        assert.throws(function() {
+          mquery().skip(3)[method]();
         }, new RegExp('skip cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('batchSize', function(done){
-        assert.throws(function(){
-          var m = mquery({}, { batchSize: 3 })[method]();
+      it('batchSize', function(done) {
+        assert.throws(function() {
+          mquery({}, { batchSize: 3 })[method]();
         }, new RegExp('batchSize cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('maxScan', function(done){
-        assert.throws(function(){
-          var m = mquery().maxScan(300)[method]();
+      it('maxScan', function(done) {
+        assert.throws(function() {
+          mquery().maxScan(300)[method]();
         }, new RegExp('maxScan cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('snapshot', function(done){
-        assert.throws(function(){
-          var m = mquery().snapshot()[method]();
+      it('snapshot', function(done) {
+        assert.throws(function() {
+          mquery().snapshot()[method]();
         }, new RegExp('snapshot cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('hint', function(done){
-        assert.throws(function(){
-          var m = mquery().hint({ x: 1 })[method]();
+      it('hint', function(done) {
+        assert.throws(function() {
+          mquery().hint({ x: 1 })[method]();
         }, new RegExp('hint cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('tailable', function(done){
-        assert.throws(function(){
-          var m = mquery().tailable()[method]();
+      it('tailable', function(done) {
+        assert.throws(function() {
+          mquery().tailable()[method]();
         }, new RegExp('tailable cannot be used with ' + method));
         done();
-      })
+      });
 
-      it('comment', function(done){
-        assert.throws(function(){
-          var m = mquery().comment('mquery')[method]();
+      it('comment', function(done) {
+        assert.throws(function() {
+          mquery().comment('mquery')[method]();
         }, new RegExp('comment cannot be used with ' + method));
         done();
-      })
-    })
+      });
+    });
   }
 
-  describe('findOneAndUpdate', function(){
-    var name = 'findOneAndUpdate + fn'
+  describe('findOneAndUpdate', function() {
+    var name = 'findOneAndUpdate + fn';
 
     validateFindAndModifyOptions('findOneAndUpdate');
 
-    describe('with 0 args', function(){
-      it('makes no changes', function(){
+    describe('with 0 args', function() {
+      it('makes no changes', function() {
         var m = mquery();
         var n = m.findOneAndUpdate();
         assert.deepEqual(m, n);
-      })
-    })
-    describe('with 1 arg', function(){
-      describe('that is an object', function(){
-        it('updates the doc', function(){
+      });
+    });
+    describe('with 1 arg', function() {
+      describe('that is an object', function() {
+        it('updates the doc', function() {
           var m = mquery();
           var n = m.findOneAndUpdate({ $set: { name: '1 arg' }});
           assert.deepEqual(n._update, { $set: { name: '1 arg' }});
-        })
-      })
-      describe('that is a query', function(){
-        it('updates the doc', function(){
+        });
+      });
+      describe('that is a query', function() {
+        it('updates the doc', function() {
           var m = mquery({ name: name }).update({ x: 1 });
           var n = mquery().findOneAndUpdate(m);
           assert.deepEqual(n._update, { x: 1 });
-        })
-      })
-      it('that is a function', function(done){
-        col.insert({ name: name }, { safe: true }, function (err) {
+        });
+      });
+      it('that is a function', function(done) {
+        col.insert({ name: name }, { safe: true }, function(err) {
           assert.ifError(err);
           var m = mquery({ name: name }).collection(col);
           name = '1 arg';
           var n = m.update({ $set: { name: name }});
-          n.findOneAndUpdate(function (err, res) {
+          n.findOneAndUpdate(function(err, res) {
             assert.ifError(err);
             assert.ok(res.value);
             assert.equal(name, res.value.name);
             done();
           });
-        })
-      })
-    })
-    describe('with 2 args', function(){
-      it('conditions + update', function(){
+        });
+      });
+    });
+    describe('with 2 args', function() {
+      it('conditions + update', function() {
         var m = mquery(col);
         m.findOneAndUpdate({ name: name }, { age: 100 });
         assert.deepEqual({ name: name }, m._conditions);
         assert.deepEqual({ age: 100 }, m._update);
-      })
-      it('query + update', function(){
+      });
+      it('query + update', function() {
         var n = mquery({ name: name });
         var m = mquery(col);
         m.findOneAndUpdate(n, { age: 100 });
         assert.deepEqual({ name: name }, m._conditions);
         assert.deepEqual({ age: 100 }, m._update);
-      })
-      it('update + callback', function(done){
+      });
+      it('update + callback', function(done) {
         var m = mquery(col).where({ name: name });
-        m.findOneAndUpdate({}, { $inc: { age: 10 }}, { new: true }, function (err, res) {
+        m.findOneAndUpdate({}, { $inc: { age: 10 }}, { new: true }, function(err, res) {
           assert.ifError(err);
           assert.equal(10, res.value.age);
           done();
         });
-      })
-    })
-    describe('with 3 args', function(){
-      it('conditions + update + options', function(){
+      });
+    });
+    describe('with 3 args', function() {
+      it('conditions + update + options', function() {
         var m = mquery();
         var n = m.findOneAndUpdate({ name: name }, { works: true }, { new: false });
         assert.deepEqual({ name: name}, n._conditions);
         assert.deepEqual({ works: true }, n._update);
         assert.deepEqual({ new: false }, n.options);
-      })
-      it('conditions + update + callback', function(done){
+      });
+      it('conditions + update + callback', function(done) {
         var m = mquery(col);
-        m.findOneAndUpdate({ name: name }, { works: true }, { new: true }, function (err, res) {
+        m.findOneAndUpdate({ name: name }, { works: true }, { new: true }, function(err, res) {
           assert.ifError(err);
           assert.ok(res.value);
           assert.equal(name, res.value.name);
           assert.ok(true === res.value.works);
           done();
         });
-      })
-    })
-    describe('with 4 args', function(){
-      it('conditions + update + options + callback', function(done){
+      });
+    });
+    describe('with 4 args', function() {
+      it('conditions + update + options + callback', function(done) {
         var m = mquery(col);
-        m.findOneAndUpdate({ name: name }, { works: false }, { new: false },  function (err, res) {
+        m.findOneAndUpdate({ name: name }, { works: false }, { new: false }, function(err, res) {
           assert.ifError(err);
           assert.ok(res.value);
           assert.equal(name, res.value.name);
           assert.ok(true === res.value.works);
           done();
         });
-      })
-    })
-  })
+      });
+    });
+  });
 
-  describe('findOneAndRemove', function(){
-    var name = 'findOneAndRemove'
+  describe('findOneAndRemove', function() {
+    var name = 'findOneAndRemove';
 
     validateFindAndModifyOptions('findOneAndRemove');
 
-    describe('with 0 args', function(){
-      it('makes no changes', function(){
+    describe('with 0 args', function() {
+      it('makes no changes', function() {
         var m = mquery();
         var n = m.findOneAndRemove();
         assert.deepEqual(m, n);
-      })
-    })
-    describe('with 1 arg', function(){
-      describe('that is an object', function(){
-        it('updates the doc', function(){
+      });
+    });
+    describe('with 1 arg', function() {
+      describe('that is an object', function() {
+        it('updates the doc', function() {
           var m = mquery();
           var n = m.findOneAndRemove({ name: '1 arg' });
           assert.deepEqual(n._conditions, { name: '1 arg' });
-        })
-      })
-      describe('that is a query', function(){
-        it('updates the doc', function(){
+        });
+      });
+      describe('that is a query', function() {
+        it('updates the doc', function() {
           var m = mquery({ name: name });
           var n = m.findOneAndRemove(m);
           assert.deepEqual(n._conditions, { name: name });
-        })
-      })
-      it('that is a function', function(done){
-        col.insert({ name: name }, { safe: true }, function (err) {
+        });
+      });
+      it('that is a function', function(done) {
+        col.insert({ name: name }, { safe: true }, function(err) {
           assert.ifError(err);
           var m = mquery({ name: name }).collection(col);
-          m.findOneAndRemove(function (err, res) {
+          m.findOneAndRemove(function(err, res) {
             assert.ifError(err);
             assert.ok(res.value);
             assert.equal(name, res.value.name);
             done();
           });
-        })
-      })
-    })
-    describe('with 2 args', function(){
-      it('conditions + options', function(){
+        });
+      });
+    });
+    describe('with 2 args', function() {
+      it('conditions + options', function() {
         var m = mquery(col);
         m.findOneAndRemove({ name: name }, { new: false });
         assert.deepEqual({ name: name }, m._conditions);
         assert.deepEqual({ new: false }, m.options);
-      })
-      it('query + options', function(){
+      });
+      it('query + options', function() {
         var n = mquery({ name: name });
         var m = mquery(col);
         m.findOneAndRemove(n, { sort: { x: 1 }});
         assert.deepEqual({ name: name }, m._conditions);
         assert.deepEqual({ sort: { 'x': 1 }}, m.options);
-      })
-      it('conditions + callback', function(done){
-        col.insert({ name: name }, { safe: true }, function (err) {
+      });
+      it('conditions + callback', function(done) {
+        col.insert({ name: name }, { safe: true }, function(err) {
           assert.ifError(err);
           var m = mquery(col);
-          m.findOneAndRemove({ name: name }, function (err, res) {
+          m.findOneAndRemove({ name: name }, function(err, res) {
             assert.ifError(err);
             assert.equal(name, res.value.name);
             done();
           });
         });
-      })
-      it('query + callback', function(done){
-        col.insert({ name: name }, { safe: true }, function (err) {
+      });
+      it('query + callback', function(done) {
+        col.insert({ name: name }, { safe: true }, function(err) {
           assert.ifError(err);
-          var n = mquery({ name: name })
+          var n = mquery({ name: name });
           var m = mquery(col);
-          m.findOneAndRemove(n, function (err, res) {
+          m.findOneAndRemove(n, function(err, res) {
             assert.ifError(err);
             assert.equal(name, res.value.name);
             done();
           });
         });
-      })
-    })
-    describe('with 3 args', function(){
-      it('conditions + options + callback', function(done){
+      });
+    });
+    describe('with 3 args', function() {
+      it('conditions + options + callback', function(done) {
         name = 'findOneAndRemove + conds + options + cb';
-        col.insert([{ name: name }, { name: 'a' }], { safe: true }, function (err) {
+        col.insert([{ name: name }, { name: 'a' }], { safe: true }, function(err) {
           assert.ifError(err);
           var m = mquery(col);
-          m.findOneAndRemove({ name: name }, { sort: { name: 1 }}, function (err, res) {
+          m.findOneAndRemove({ name: name }, { sort: { name: 1 }}, function(err, res) {
             assert.ifError(err);
             assert.ok(res.value);
             assert.equal(name, res.value.name);
             done();
           });
-        })
-      })
-    })
-  })
+        });
+      });
+    });
+  });
 
-  describe('exec', function(){
-    beforeEach(function(done){
+  describe('exec', function() {
+    beforeEach(function(done) {
       col.insert([{ name: 'exec', age: 1 }, { name: 'exec', age: 2 }], done);
-    })
+    });
 
-    afterEach(function(done){
+    afterEach(function(done) {
       mquery(col).remove(done);
-    })
+    });
 
-    it('requires an op', function(){
-      assert.throws(function () {
-        mquery().exec()
+    it('requires an op', function() {
+      assert.throws(function() {
+        mquery().exec();
       }, /Missing query type/);
-    })
+    });
 
     describe('find', function() {
-      it('works', function(done){
+      it('works', function(done) {
         var m = mquery(col).find({ name: 'exec' });
-        m.exec(function (err, docs) {
+        m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);
           done();
-        })
-      })
+        });
+      });
 
-      it('works with readPreferences', function (done) {
+      it('works with readPreferences', function(done) {
         var m = mquery(col).find({ name: 'exec' });
         try {
           var rp = new require('mongodb').ReadPreference('primary');
           m.read(rp);
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND')
-            e = null;
-          done(e);
+          done(e.code === 'MODULE_NOT_FOUND' ? null : e);
           return;
         }
-        m.exec(function (err, docs) {
+        m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);
           done();
-        })
-      })
+        });
+      });
 
-      it('works with readConcern', function (done) {
+      it('works with readConcern', function(done) {
         var m = mquery(col).find({ name: 'exec' });
         try {
           m.readConcern('l');
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND')
-            e = null;
-          done(e);
+          done(e.code === 'MODULE_NOT_FOUND' ? null : e);
           return;
         }
-        m.exec(function (err, docs) {
+        m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);
           done();
-        })
-      })
+        });
+      });
 
-      it('works with collation', function (done) {
+      it('works with collation', function(done) {
         var m = mquery(col).find({ name: 'EXEC' });
         try {
-          m.collation({ locale: "en_US", strength: 1 })
+          m.collation({ locale: 'en_US', strength: 1 });
         } catch (e) {
-          if (e.code === 'MODULE_NOT_FOUND')
-            e = null;
-          done(e);
+          done(e.code === 'MODULE_NOT_FOUND' ? null : e);
           return;
         }
-        m.exec(function (err, docs) {
+        m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);
           done();
-        })
-      })
+        });
+      });
     });
 
-    it('findOne', function(done){
+    it('findOne', function(done) {
       var m = mquery(col).findOne({ age: 2 });
-      m.exec(function (err, doc) {
+      m.exec(function(err, doc) {
         assert.ifError(err);
         assert.equal(2, doc.age);
         done();
-      })
-    })
+      });
+    });
 
-    it('count', function(done){
+    it('count', function(done) {
       var m = mquery(col).count({ name: 'exec' });
-      m.exec(function (err, count) {
+      m.exec(function(err, count) {
         assert.ifError(err);
         assert.equal(2, count);
         done();
-      })
-    })
+      });
+    });
 
-    it('distinct', function(done){
+    it('distinct', function(done) {
       var m = mquery({ name: 'exec' });
       m.collection(col);
       m.distinct('age');
-      m.exec(function (err, array) {
+      m.exec(function(err, array) {
         assert.ifError(err);
         assert.ok(Array.isArray(array));
         assert.equal(2, array.length);
@@ -2600,31 +2609,31 @@ describe('mquery', function(){
         assert(~array.indexOf(2));
         done();
       });
-    })
+    });
 
-    describe('update', function(){
+    describe('update', function() {
       var num;
 
-      it('with a callback', function(done){
+      it('with a callback', function(done) {
         var m = mquery(col);
-        m.where({ name: 'exec' })
+        m.where({ name: 'exec' });
 
-        m.count(function (err, _num) {
+        m.count(function(err, _num) {
           assert.ifError(err);
           num = _num;
-          m.setOptions({ multi: true })
+          m.setOptions({ multi: true });
           m.update({ name: 'exec + update' });
-          m.exec(function (err, res) {
+          m.exec(function(err, res) {
             assert.ifError(err);
             assert.equal(num, res.result.n);
-            mquery(col).find({ name: 'exec + update' }, function (err, docs) {
+            mquery(col).find({ name: 'exec + update' }, function(err, docs) {
               assert.ifError(err);
               assert.equal(num, docs.length);
               done();
-            })
-          })
-        })
-      })
+            });
+          });
+        });
+      });
 
       describe('updateMany', function() {
         it('works', function(done) {
@@ -2669,22 +2678,22 @@ describe('mquery', function(){
         });
       });
 
-      it('without a callback', function(done){
-        var m = mquery(col)
-        m.where({ name: 'exec + update' }).setOptions({ multi: true })
+      it('without a callback', function(done) {
+        var m = mquery(col);
+        m.where({ name: 'exec + update' }).setOptions({ multi: true });
         m.update({ name: 'exec' });
 
         // unsafe write
         m.exec();
 
-        setTimeout(function () {
-          mquery(col).find({ name: 'exec' }, function (err, docs) {
+        setTimeout(function() {
+          mquery(col).find({ name: 'exec' }, function(err, docs) {
             assert.ifError(err);
             assert.equal(2, docs.length);
             done();
-          })
-        }, 200)
-      })
+          });
+        }, 200);
+      });
       it('preserves key ordering', function(done) {
         var m = mquery(col);
 
@@ -2696,113 +2705,113 @@ describe('mquery', function(){
             assert.equal('1', i);
           } else if (count == 1) {
             assert.equal('2', i);
-          } else if (count ==2) {
+          } else if (count == 2) {
             assert.equal('3', i);
           }
           count++;
         }
         done();
       });
-    })
+    });
 
-    describe('remove', function(){
-      it('with a callback', function(done){
+    describe('remove', function() {
+      it('with a callback', function(done) {
         var m = mquery(col).where({ age: 2 }).remove();
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal(1, res.result.n);
           done();
-        })
-      })
+        });
+      });
 
-      it('without a callback', function(done){
+      it('without a callback', function(done) {
         var m = mquery(col).where({ age: 1 }).remove();
         m.exec();
 
-        setTimeout(function () {
+        setTimeout(function() {
           mquery(col).where('name', 'exec').count(function(err, num) {
             assert.equal(1, num);
             done();
-          })
-        }, 200)
-      })
-    })
+          });
+        }, 200);
+      });
+    });
 
-    describe('deleteOne', function(){
-      it('with a callback', function(done){
+    describe('deleteOne', function() {
+      it('with a callback', function(done) {
         var m = mquery(col).where({ age: { $gte: 0 } }).deleteOne();
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal(res.result.n, 1);
           done();
-        })
-      })
+        });
+      });
 
-      it('with justOne set', function(done){
+      it('with justOne set', function(done) {
         var m = mquery(col).where({ age: { $gte: 0 } }).
           // Should ignore `justOne`
           setOptions({ justOne: false }).
           deleteOne();
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal(res.result.n, 1);
           done();
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('deleteMany', function(){
-      it('with a callback', function(done){
+    describe('deleteMany', function() {
+      it('with a callback', function(done) {
         var m = mquery(col).where({ age: { $gte: 0 } }).deleteMany();
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal(res.result.n, 2);
           done();
-        })
-      })
-    })
+        });
+      });
+    });
 
-    describe('findOneAndUpdate', function(){
-      it('with a callback', function(done){
+    describe('findOneAndUpdate', function() {
+      it('with a callback', function(done) {
         var m = mquery(col);
         m.findOneAndUpdate({ name: 'exec', age: 1 }, { $set: { name: 'findOneAndUpdate' }});
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal('findOneAndUpdate', res.value.name);
           done();
         });
-      })
-    })
+      });
+    });
 
-    describe('findOneAndRemove', function(){
-      it('with a callback', function(done){
+    describe('findOneAndRemove', function() {
+      it('with a callback', function(done) {
         var m = mquery(col);
         m.findOneAndRemove({ name: 'exec', age: 2 });
-        m.exec(function (err, res) {
+        m.exec(function(err, res) {
           assert.ifError(err);
           assert.equal('exec', res.value.name);
           assert.equal(2, res.value.age);
-          mquery(col).count({ name: 'exec' }, function (err, num) {
+          mquery(col).count({ name: 'exec' }, function(err, num) {
             assert.ifError(err);
             assert.equal(1, num);
             done();
           });
         });
-      })
-    })
-  })
+      });
+    });
+  });
 
   describe('setTraceFunction', function() {
-    beforeEach(function(done){
+    beforeEach(function(done) {
       col.insert([{ name: 'trace', age: 93 }], done);
-    })
+    });
 
     it('calls trace function when executing query', function(done) {
       var m = mquery(col);
 
       var resultTraceCalled;
 
-      m.setTraceFunction(function (method, queryInfo) {
+      m.setTraceFunction(function(method, queryInfo) {
         try {
           assert.equal('findOne', method);
           assert.equal('trace', queryInfo.conditions.name);
@@ -2813,6 +2822,7 @@ describe('mquery', function(){
         return function(err, result, millis) {
           try {
             assert.equal(93, result.age);
+            assert.ok(typeof millis === 'number');
           } catch (e) {
             done(e);
           }
@@ -2820,7 +2830,7 @@ describe('mquery', function(){
         };
       });
 
-      m.findOne({name: 'trace'}, function (err, doc) {
+      m.findOne({name: 'trace'}, function(err, doc) {
         assert.ifError(err);
         assert.equal(resultTraceCalled, true);
         assert.equal(93, doc.age);
@@ -2829,7 +2839,7 @@ describe('mquery', function(){
     });
 
     it('inherits trace function when calling toConstructor', function(done) {
-      function traceFunction () { return function() {} };
+      function traceFunction() { return function() {}; }
 
       var tracedQuery = mquery().setTraceFunction(traceFunction).toConstructor();
 
@@ -2854,20 +2864,20 @@ describe('mquery', function(){
         assert.equal(this, m);
         assert.equal(cb, fn);
         done();
-      }
+      };
 
       m.thunk()(cb);
     });
   });
 
   describe('then', function() {
-    before(function(done){
+    before(function(done) {
       col.insert([{ name: 'then', age: 1 }, { name: 'then', age: 2 }], done);
-    })
+    });
 
-    after(function(done){
+    after(function(done) {
       mquery(col).remove({ name: 'then' }).exec(done);
-    })
+    });
 
     it('returns a promise A+ compat object', function(done) {
       var m = mquery(col).find();
@@ -2877,7 +2887,7 @@ describe('mquery', function(){
 
     it('creates a promise that is resolved on success', function(done) {
       var promise = mquery(col).count({ name: 'then' }).then();
-      promise.then(function(count){
+      promise.then(function(count) {
         assert.equal(2, count);
         done();
       }, done);
@@ -2887,10 +2897,10 @@ describe('mquery', function(){
       var query = mquery(col).count({ name: 'then' });
       query.exec = function(cb) {
         cb(null, 66);
-      }
+      };
 
       query.then(success, done);
-      function success(count){
+      function success(count) {
         assert.equal(66, count);
         done();
       }
@@ -2904,8 +2914,8 @@ describe('mquery', function(){
         mquery.Promise = bluebird;
         this.then = function(x, y) {
           return x + y;
-        }
-      }
+        };
+      };
 
       var val = mquery(col).count({ name: 'exec' }).then(1, 2);
       assert.equal(val, 3);
@@ -2914,20 +2924,20 @@ describe('mquery', function(){
   });
 
   describe('stream', function() {
-    before(function(done){
+    before(function(done) {
       col.insert([{ name: 'stream', age: 1 }, { name: 'stream', age: 2 }], done);
-    })
+    });
 
-    after(function(done){
+    after(function(done) {
       mquery(col).remove({ name: 'stream' }).exec(done);
-    })
+    });
 
     describe('throws', function() {
       describe('if used with non-find operations', function() {
         var ops = ['update', 'findOneAndUpdate', 'remove', 'count', 'distinct'];
 
         ops.forEach(function(op) {
-          assert.throws(function(){
+          assert.throws(function() {
             mquery(col)[op]().stream();
           });
         });
@@ -2939,7 +2949,7 @@ describe('mquery', function(){
       var count = 0;
       var err;
 
-      stream.on('data', function(doc){
+      stream.on('data', function(doc) {
         assert.equal('stream', doc.name);
         ++count;
       });
@@ -2948,7 +2958,7 @@ describe('mquery', function(){
         err = er;
       });
 
-      stream.on('end', function(){
+      stream.on('end', function() {
         if (err) return done(err);
         assert.equal(2, count);
         done();
@@ -2956,28 +2966,28 @@ describe('mquery', function(){
     });
   });
 
-  function noDistinct (type) {
-    it('cannot be used with distinct()', function(done){
-      assert.throws(function () {
+  function noDistinct(type) {
+    it('cannot be used with distinct()', function(done) {
+      assert.throws(function() {
         mquery().distinct('name')[type](4);
       }, new RegExp(type + ' cannot be used with distinct'));
       done();
-    })
+    });
   }
 
-  function no (method, type) {
-    it('cannot be used with ' + method + '()', function(done){
-      assert.throws(function () {
+  function no(method, type) {
+    it('cannot be used with ' + method + '()', function(done) {
+      assert.throws(function() {
         mquery()[method]()[type](4);
       }, new RegExp(type + ' cannot be used with ' + method));
       done();
-    })
+    });
   }
 
   // query internal
 
-  describe('_updateForExec', function(){
-    it('returns a clone of the update object with same key order #19', function(done){
+  describe('_updateForExec', function() {
+    it('returns a clone of the update object with same key order #19', function(done) {
       var update = {};
       update.$push = { n: { $each: [{x:10}], $slice: -1, $sort: {x:1}}};
 
@@ -2985,19 +2995,20 @@ describe('mquery', function(){
 
       // capture original key order
       var order = [];
-      for (var key in q._update.$push.n) {
+      var key;
+      for (key in q._update.$push.n) {
         order.push(key);
       }
 
       // compare output
       var doc = q._updateForExec();
       var i = 0;
-      for (var key in doc.$push.n) {
+      for (key in doc.$push.n) {
         assert.equal(key, order[i]);
         i++;
       }
 
       done();
-    })
-  })
-})
+    });
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,16 +1,19 @@
 
 var utils = require('../lib/utils');
 var assert = require('assert');
+var debug = require('debug');
 
 var mongo;
 try {
   mongo = new require('mongodb');
-} catch (e) {}
+} catch (e) {
+  debug('mongo', 'cannot construct mongodb instance');
+}
 
 describe('lib/utils', function() {
   describe('clone', function() {
     it('clones constructors named ObjectId', function(done) {
-      function ObjectId (id) {
+      function ObjectId(id) {
         this.id = id;
       }
 
@@ -22,7 +25,7 @@ describe('lib/utils', function() {
     });
 
     it('clones constructors named ObjectID', function(done) {
-      function ObjectID (id) {
+      function ObjectID(id) {
         this.id = id;
       }
 
@@ -34,7 +37,7 @@ describe('lib/utils', function() {
     });
 
     it('does not clone constructors named ObjectIdd', function(done) {
-      function ObjectIdd (id) {
+      function ObjectIdd(id) {
         this.id = id;
       }
 
@@ -46,16 +49,16 @@ describe('lib/utils', function() {
     });
 
     it('optionally clones ObjectId constructors using its clone method', function(done) {
-      function ObjectID (id) {
+      function ObjectID(id) {
         this.id = id;
         this.cloned = false;
       }
 
-      ObjectID.prototype.clone = function () {
+      ObjectID.prototype.clone = function() {
         var ret = new ObjectID(this.id);
         ret.cloned = true;
         return ret;
-      }
+      };
 
       var id = 1234;
       var o1 = new ObjectID(id);
@@ -69,17 +72,17 @@ describe('lib/utils', function() {
       done();
     });
 
-    it('clones mongodb.ReadPreferences', function (done) {
+    it('clones mongodb.ReadPreferences', function(done) {
       if (!mongo) return done();
 
       var tags = [
         {dc: 'tag1'}
       ];
       var prefs = [
-        new mongo.ReadPreference("primary"),
+        new mongo.ReadPreference('primary'),
         new mongo.ReadPreference(mongo.ReadPreference.PRIMARY_PREFERRED),
-        new mongo.ReadPreference("primary", tags),
-        mongo.ReadPreference("primary", tags)
+        new mongo.ReadPreference('primary', tags),
+        mongo.ReadPreference('primary', tags)
       ];
 
       var prefsCloned = utils.clone(prefs);
@@ -100,20 +103,20 @@ describe('lib/utils', function() {
       done();
     });
 
-    it('clones mongodb.Binary', function(done){
+    it('clones mongodb.Binary', function(done) {
       if (!mongo) return done();
 
       var buf = Buffer.from('hi');
-      var binary= new mongo.Binary(buf, 2);
+      var binary = new mongo.Binary(buf, 2);
       var clone = utils.clone(binary);
       assert.equal(binary.sub_type, clone.sub_type);
       assert.equal(String(binary.buffer), String(buf));
       assert.ok(binary !== clone);
       done();
-    })
+    });
 
     it('handles objects with no constructor', function(done) {
-      var name ='335';
+      var name = '335';
 
       var o = Object.create(null);
       o.name = name;
@@ -128,7 +131,7 @@ describe('lib/utils', function() {
       done();
     });
 
-    it('handles buffers', function(done){
+    it('handles buffers', function(done) {
       var buff = Buffer.alloc(10);
       buff.fill(1);
       var clone = utils.clone(buff);


### PR DESCRIPTION
A lot of non-breaking improvements

- Add eslint and use the same style configuration with `mongoose`
  except for `es6` and `ecmaVersion` for compability. `mquery` uses ES5.
  Any idea for different styles configuration?
- Bump mocha, sliced, debug, bluebird versions without breaking changes.
- Now test node v10 in travis-ci (for `npm audit` security check, see below)
- Deprecate `nsp check`
  - `nsp` is [shutting down on 2018/09/30](https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting) and the test may fail after that date.
  - use `npm audit` now to test on `npm@6+`
    `npm install` automatically run with `npm audit` so no need to add it in test script when using npm@6+ which is the version that travis-ci uses in node v10. See Automattic/mongoose#6514 . If we specify `npm audit` in the test script it will fail on old version of npm.
- Update README.md
  - Place maxTime and maxTimeMS in the same line to show that they are just alias of each other.
  - Use new travis-ci svg badge to support high-resolution image.
  Before: ![Build Status](https://travis-ci.org/aheckmann/mquery.png) After: ![Build Status](https://travis-ci.org/aheckmann/mquery.svg?branch=master)
  - Add npm version and install badges
- Bug Fixes. fix some potential errors with the help of linter.

  eslint: `streamOptions` is defined but not used. missing `.stream(streamOptions)` here
  https://github.com/aheckmann/mquery/blob/c35c64eb1268d388c48757d4002d09ebec8021f9/lib/collection/node.js#L126-L132

  eslint: `field` is undefined. should be `key` here
  https://github.com/aheckmann/mquery/blob/c4de96f3013606c6d2e9d4ea63123f1141ed443e/lib/mquery.js#L1343-L1356

  Actually, #103 is also found by VSCode built-in linter

IMO, add linter is good as it can help to spot errors early without testing.