### PR TITLE
Add Write Concern support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ require('mongodb').connect(uri, function (err, db) {
 - [maxTime, maxTimeMS](#maxtime)
 - [skip](#skip)
 - [sort](#sort)
-- [read](#read)
+- [read, setReadPreference](#read)
 - [readConcern, r](#readconcern)
 - [slaveOk](#slaveok)
 - [snapshot](#snapshot)
@@ -969,6 +969,8 @@ mquery().read('sp') // same as secondaryPreferred
 
 mquery().read('nearest')
 mquery().read('n')  // same as nearest
+
+mquery().setReadPreference('primary') // alias of .read()
 ```
 
 ##### Preferences:

--- a/README.md
+++ b/README.md
@@ -90,16 +90,19 @@ require('mongodb').connect(uri, function (err, db) {
 - [collation](#collation)
 - [comment](#comment)
 - [hint](#hint)
+- [j](#j)
 - [limit](#limit)
 - [maxScan](#maxscan)
 - [maxTime, maxTimeMS](#maxtime)
 - [skip](#skip)
 - [sort](#sort)
 - [read](#read)
-- [readConcern](#readconcern)
+- [readConcern, r](#readconcern)
 - [slaveOk](#slaveok)
 - [snapshot](#snapshot)
 - [tailable](#tailable)
+- [writeConcern, w](#writeconcern)
+- [wtimeout, wTimeout](#wtimeout)
 
 ## Helpers
 
@@ -860,6 +863,27 @@ _Cannot be used with `distinct()`._
 
 [MongoDB documentation](http://docs.mongodb.org/manual/reference/operator/hint/)
 
+### j()
+
+Requests acknowledgement that this operation has been persisted to MongoDB's on-disk journal.
+
+This option is only valid for operations that write to the database:
+
+- `deleteOne()`
+- `deleteMany()`
+- `findOneAndDelete()`
+- `findOneAndUpdate()`
+- `remove()`
+- `update()`
+- `updateOne()`
+- `updateMany()`
+
+Defaults to the `j` value if it is specified in [writeConcern](#writeconcern)
+
+```js
+mquery().j(true);
+```
+
 ### limit()
 
 Specifies the limit option.
@@ -986,20 +1010,30 @@ Read more about how to use read preferences [here](http://docs.mongodb.org/manua
 Sets the readConcern option for the query.
 
 ```js
+// local
 mquery().readConcern('local')
-mquery().readConcern('l')  // same as local
+mquery().readConcern('l')
+mquery().r('l')
 
+// available
 mquery().readConcern('available')
-mquery().readConcern('a')  // same as available
+mquery().readConcern('a')
+mquery().r('a')
 
+// majority
 mquery().readConcern('majority')
-mquery().readConcern('m')  // same as majority
+mquery().readConcern('m')
+mquery().r('m')
 
+// linearizable
 mquery().readConcern('linearizable')
-mquery().readConcern('lz') // same as linearizable
+mquery().readConcern('lz')
+mquery().r('lz')
 
+// snapshot
 mquery().readConcern('snapshot')
-mquery().readConcern('s')  // same as snapshot
+mquery().readConcern('s')
+mquery().r('s')
 ```
 
 ##### Read Concern Level:
@@ -1019,6 +1053,45 @@ Aliases
 - `s`   snapshot
 
 Read more about how to use read concern [here](https://docs.mongodb.com/manual/reference/read-concern/).
+
+### writeConcern()
+
+Sets the writeConcern option for the query.
+
+This option is only valid for operations that write to the database:
+
+- `deleteOne()`
+- `deleteMany()`
+- `findOneAndDelete()`
+- `findOneAndUpdate()`
+- `remove()`
+- `update()`
+- `updateOne()`
+- `updateMany()`
+
+```js
+mquery().writeConcern(0)
+mquery().writeConcern(1)
+mquery().writeConcern({ w: 1, j: true, wtimeout: 2000 })
+mquery().writeConcern('majority')
+mquery().writeConcern('m') // same as majority
+mquery().writeConcern('tagSetName') // if the tag set is 'm', use .writeConcern({ w: 'm' }) instead
+mquery().w(1) // w is alias of writeConcern
+```
+
+##### Write Concern:
+
+writeConcern({ w: `<value>`, j: `<boolean>`, wtimeout: `<number>` }`)
+
+- the w option to request acknowledgement that the write operation has propagated to a specified number of mongod instances or to mongod instances with specified tags
+- the j option to request acknowledgement that the write operation has been written to the journal
+- the wtimeout option to specify a time limit to prevent write operations from blocking indefinitely
+
+Can be break down to use the following syntax:
+
+mquery().w(`<value>`).j(`<boolean>`).wtimeout(`<number>`)
+
+Read more about how to use write concern [here](https://docs.mongodb.com/manual/reference/write-concern/)
 
 ### slaveOk()
 
@@ -1061,6 +1134,29 @@ mquery().tailable(false)
 _Cannot be used with `distinct()`._
 
 [MongoDB Documentation](http://docs.mongodb.org/manual/tutorial/create-tailable-cursor/)
+
+### wtimeout()
+
+Specifies a time limit, in milliseconds, for the write concern. If `w > 1`, it is maximum amount of time to
+wait for this write to propagate through the replica set before this operation fails. The default is `0`, which means no timeout.
+
+This option is only valid for operations that write to the database:
+
+- `deleteOne()`
+- `deleteMany()`
+- `findOneAndDelete()`
+- `findOneAndUpdate()`
+- `remove()`
+- `update()`
+- `updateOne()`
+- `updateMany()`
+
+Defaults to `wtimeout` value if it is specified in [writeConcern](#writeconcern)
+
+```js
+mquery().wtimeout(2000)
+mquery().wTimeout(2000)
+```
 
 ## Helpers
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require('mongodb').connect(uri, function (err, db) {
 - [remove](#remove)
 - [update](#update)
 - [findOneAndUpdate](#findoneandupdate)
-- [findOneAndRemove](#findoneandremove)
+- [findOneAndDelete, findOneAndRemove](#findoneandremove)
 - [distinct](#distinct)
 - [exec](#exec)
 - [stream](#stream)
@@ -290,7 +290,8 @@ query.findOneAndUpdate(match, updateDocument, options, function (err, doc) {
 
 ### findOneAndRemove()
 
-Declares this query a _findAndModify_ with remove query. Optionally pass a match clause, options, or callback. If a callback is passed, the query is executed.
+Declares this query a _findAndModify_ with remove query. Alias of findOneAndDelete.
+Optionally pass a match clause, options, or callback. If a callback is passed, the query is executed.
 
 When executed, the first matching document (if found) is modified according to the update document, removed from the collection and passed to the callback.
 
@@ -301,6 +302,7 @@ Options are passed to the `setOptions()` method.
 - `sort`: if multiple docs are found by the condition, sets the sort order to choose which doc to modify and remove
 
 ```js
+A.where().findOneAndDelete()
 A.where().findOneAndRemove()
 A.where().findOneAndRemove(match)
 A.where().findOneAndRemove(match, options)

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1472,14 +1472,14 @@ function _pushMap(opts, map) {
  *
  * @method maxTime
  * @memberOf Query
- * @param {Number} val
+ * @param {Number} ms
  * @see mongodb http://docs.mongodb.org/manual/reference/operator/meta/maxTimeMS/#op._S_maxTimeMS
  * @api public
  */
 
-Query.prototype.maxTime = Query.prototype.maxTimeMS = function(v) {
+Query.prototype.maxTime = Query.prototype.maxTimeMS = function(ms) {
   this._validate('maxTime');
-  this.options.maxTimeMS = v;
+  this.options.maxTimeMS = ms;
   return this;
 };
 
@@ -1551,6 +1551,40 @@ Query.prototype.hint = function() {
   }
 
   throw new TypeError('Invalid hint. ' + arg);
+};
+
+/**
+ * Requests acknowledgement that this operation has been persisted to MongoDB's
+ * on-disk journal.
+ * This option is only valid for operations that write to the database:
+ *
+ * - `deleteOne()`
+ * - `deleteMany()`
+ * - `findOneAndDelete()`
+ * - `findOneAndUpdate()`
+ * - `remove()`
+ * - `update()`
+ * - `updateOne()`
+ * - `updateMany()`
+ *
+ * Defaults to the `j` value if it is specified in writeConcern options
+ *
+ * ####Example:
+ *
+ *     mquery().w(2).j(true).wtimeout(2000);
+ *
+ * @method j
+ * @memberOf Query
+ * @instance
+ * @param {boolean} val
+ * @see mongodb https://docs.mongodb.com/manual/reference/write-concern/#j-option
+ * @return {Query} this
+ * @api public
+ */
+
+Query.prototype.j = function j(val) {
+  this.options.j = val;
+  return this;
 };
 
 /**
@@ -1652,6 +1686,8 @@ Query.prototype.read = function(pref) {
  *     new Query().readConcern('snapshot')
  *     new Query().readConcern('s')  // same as snapshot
  *
+ *     new Query().r('s') // r is alias of readConcern
+ *
  *
  * ####Read Concern Level:
  *
@@ -1680,7 +1716,7 @@ Query.prototype.read = function(pref) {
  * @api public
  */
 
-Query.prototype.readConcern = function(level) {
+Query.prototype.readConcern = Query.prototype.r = function(level) {
   this.options.readConcern = utils.readConcern(level);
   return this;
 };
@@ -1710,6 +1746,89 @@ Query.prototype.tailable = function() {
     ? !!arguments[0]
     : true;
 
+  return this;
+};
+
+/**
+ * Sets the specified number of `mongod` servers, or tag set of `mongod` servers,
+ * that must acknowledge this write before this write is considered successful.
+ * This option is only valid for operations that write to the database:
+ *
+ * - `deleteOne()`
+ * - `deleteMany()`
+ * - `findOneAndDelete()`
+ * - `findOneAndUpdate()`
+ * - `remove()`
+ * - `update()`
+ * - `updateOne()`
+ * - `updateMany()`
+ *
+ * Defaults to the `w` value if it is specified in writeConcern options
+ *
+ * ####Example:
+ *
+ * mquery().writeConcern(0)
+ * mquery().writeConcern(1)
+ * mquery().writeConcern({ w: 1, j: true, wtimeout: 2000 })
+ * mquery().writeConcern('majority')
+ * mquery().writeConcern('m') // same as majority
+ * mquery().writeConcern('tagSetName') // if the tag set is 'm', use .writeConcern({ w: 'm' }) instead
+ * mquery().w(1) // w is alias of writeConcern
+ *
+ * @method writeConcern
+ * @memberOf Query
+ * @instance
+ * @param {String|number|object} concern 0 for fire-and-forget, 1 for acknowledged by one server, 'majority' for majority of the replica set, or [any of the more advanced options](https://docs.mongodb.com/manual/reference/write-concern/#w-option).
+ * @see mongodb https://docs.mongodb.com/manual/reference/write-concern/#w-option
+ * @return {Query} this
+ * @api public
+ */
+
+Query.prototype.writeConcern = Query.prototype.w = function writeConcern(concern) {
+  if ('object' === typeof concern) {
+    if ('undefined' !== typeof concern.j) this.options.j = concern.j;
+    if ('undefined' !== typeof concern.w) this.options.w = concern.w;
+    if ('undefined' !== typeof concern.wtimeout) this.options.wtimeout = concern.wtimeout;
+  } else {
+    this.options.w = 'm' === concern ? 'majority' : concern;
+  }
+  return this;
+};
+
+/**
+ * Specifies a time limit, in milliseconds, for the write concern.
+ * If `ms > 1`, it is maximum amount of time to wait for this write
+ * to propagate through the replica set before this operation fails.
+ * The default is `0`, which means no timeout.
+ *
+ * This option is only valid for operations that write to the database:
+ *
+ * - `deleteOne()`
+ * - `deleteMany()`
+ * - `findOneAndDelete()`
+ * - `findOneAndUpdate()`
+ * - `remove()`
+ * - `update()`
+ * - `updateOne()`
+ * - `updateMany()`
+ *
+ * Defaults to `wtimeout` value if it is specified in writeConcern
+ *
+ * ####Example:
+ *
+ *     mquery().w(2).j(true).wtimeout(2000)
+ *
+ * @method wtimeout
+ * @memberOf Query
+ * @instance
+ * @param {number} ms number of milliseconds to wait
+ * @see mongodb https://docs.mongodb.com/manual/reference/write-concern/#wtimeout
+ * @return {Query} this
+ * @api public
+ */
+
+Query.prototype.wtimeout = Query.prototype.wTimeout = function wtimeout(ms) {
+  this.options.wtimeout = ms;
   return this;
 };
 

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -2747,6 +2747,7 @@ Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
  *     A.where().findOneAndRemove(conditions) // returns Query
  *     A.where().findOneAndRemove(callback)   // executes
  *     A.where().findOneAndRemove()           // returns Query
+ *     A.where().findOneAndDelete()           // alias of .findOneAndRemove()
  *
  * @param {Object} [conditions]
  * @param {Object} [options]
@@ -2756,7 +2757,7 @@ Query.prototype.findOneAndUpdate = function(criteria, doc, options, callback) {
  * @api public
  */
 
-Query.prototype.findOneAndRemove = function(conditions, options, callback) {
+Query.prototype.findOneAndRemove = Query.prototype.findOneAndDelete = function(conditions, options, callback) {
   this.op = 'findOneAndRemove';
   this._validate();
 

--- a/lib/mquery.js
+++ b/lib/mquery.js
@@ -1632,6 +1632,8 @@ Query.prototype.slaveOk = function(v) {
  *     // you can also use mongodb.ReadPreference class to also specify tags
  *     new Query().read(mongodb.ReadPreference('secondary', [{ dc:'sf', s: 1 },{ dc:'ma', s: 2 }]))
  *
+ *     new Query().setReadPreference('primary') // alias of .read()
+ *
  * ####Preferences:
  *
  *     primary - (default)  Read from primary only. Operations will produce an error if primary is unavailable. Cannot be combined with tags.
@@ -1657,7 +1659,7 @@ Query.prototype.slaveOk = function(v) {
  * @api public
  */
 
-Query.prototype.read = function(pref) {
+Query.prototype.read = Query.prototype.setReadPreference = function(pref) {
   if (arguments.length > 1 && !Query.prototype.read.deprecationWarningIssued) {
     console.error('Deprecation warning: \'tags\' argument is not supported anymore in Query.read() method. Please use mongodb.ReadPreference object instead.');
     Query.prototype.read.deprecationWarningIssued = true;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -221,7 +221,7 @@ exports.readPref = function readPref(pref) {
  *     linearizable   3.4+
  *     snapshot       4.0+
  *
- * @param {String} readConcern
+ * @param {String|Object} concern
  */
 
 exports.readConcern = function readConcern(concern) {

--- a/test/index.js
+++ b/test/index.js
@@ -2595,14 +2595,22 @@ describe('mquery', function() {
         });
       });
 
+      it('works with hint', function(done) {
+        mquery(col).hint({ _id: 1 }).find({ name: 'exec' }).exec(function(err, docs) {
+          assert.ifError(err);
+          assert.equal(2, docs.length);
+
+          mquery(col).hint('_id_').find({ age: 1 }).exec(function(err, docs) {
+            assert.ifError(err);
+            assert.equal(1, docs.length);
+            done();
+          });
+        });
+      });
+
       it('works with readConcern', function(done) {
         var m = mquery(col).find({ name: 'exec' });
-        try {
-          m.readConcern('l');
-        } catch (e) {
-          done(e.code === 'MODULE_NOT_FOUND' ? null : e);
-          return;
-        }
+        m.readConcern('l');
         m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);
@@ -2612,12 +2620,7 @@ describe('mquery', function() {
 
       it('works with collation', function(done) {
         var m = mquery(col).find({ name: 'EXEC' });
-        try {
-          m.collation({ locale: 'en_US', strength: 1 });
-        } catch (e) {
-          done(e.code === 'MODULE_NOT_FOUND' ? null : e);
-          return;
-        }
+        m.collation({ locale: 'en_US', strength: 1 });
         m.exec(function(err, docs) {
           assert.ifError(err);
           assert.equal(2, docs.length);

--- a/test/index.js
+++ b/test/index.js
@@ -1287,6 +1287,13 @@ describe('mquery', function() {
     noDistinct('hint');
   });
 
+  describe('j', function() {
+    it('works', function() {
+      var m = mquery().j(true);
+      assert.equal(true, m.options.j);
+    });
+  });
+
   describe('slaveOk', function() {
     it('works', function() {
       var query;
@@ -1319,9 +1326,15 @@ describe('mquery', function() {
 
   describe('readConcern', function() {
     it('sets associated readConcern option', function() {
-      var m = mquery();
+      var m;
+
+      m = mquery();
       m.readConcern('s');
       assert.deepEqual({ level: 'snapshot' }, m.options.readConcern);
+
+      m = mquery();
+      m.r('local');
+      assert.deepEqual({ level: 'local' }, m.options.readConcern);
     });
     it('is chainable', function() {
       var m = mquery();
@@ -1351,6 +1364,40 @@ describe('mquery', function() {
     });
     noDistinct('tailable');
     no('count', 'tailable');
+  });
+
+  describe('writeConcern', function() {
+    it('sets associated writeConcern option', function() {
+      var m;
+      m = mquery();
+      m.writeConcern('majority');
+      assert.equal('majority', m.options.w);
+
+      m = mquery();
+      m.writeConcern('m'); // m is alias of majority
+      assert.equal('majority', m.options.w);
+
+      m = mquery();
+      m.writeConcern(1);
+      assert.equal(1, m.options.w);
+    });
+    it('accepts object', function() {
+      var m;
+
+      m = mquery().writeConcern({ w: 'm', j: true, wtimeout: 1000 });
+      assert.equal('m', m.options.w); // check it does not convert m to majority
+      assert.equal(true, m.options.j);
+      assert.equal(1000, m.options.wtimeout);
+
+      m = mquery().w('m').w({j: false, wtimeout: 0 });
+      assert.equal('majority', m.options.w);
+      assert.strictEqual(false, m.options.j);
+      assert.strictEqual(0, m.options.wtimeout);
+    });
+    it('is chainable', function() {
+      var m = mquery();
+      assert.equal(m, m.writeConcern('majority'));
+    });
   });
 
   // query utilities
@@ -2639,6 +2686,18 @@ describe('mquery', function() {
         it('works', function(done) {
           mquery(col).updateMany({ name: 'exec' }, { name: 'test' }).
             exec(function(error) {
+              assert.ifError(error);
+              mquery(col).count({ name: 'test' }).exec(function(error, res) {
+                assert.ifError(error);
+                assert.equal(res, 2);
+                done();
+              });
+            });
+        });
+        it('works with write concern', function(done) {
+          mquery(col).updateMany({ name: 'exec' }, { name: 'test' })
+            .w(1).j(true).wtimeout(1000)
+            .exec(function(error) {
               assert.ifError(error);
               mquery(col).count({ name: 'test' }).exec(function(error, res) {
                 assert.ifError(error);


### PR DESCRIPTION
## Add write concern helpers
`w writeConcern` `j` `wtimeout wTimeout`

```js
mquery().writeConcern(1)
mquery().writeConcern({ w: 1, j: true, wtimeout: 2000 })
mquery().w(1).j(true).wtimeout(2000)
mquery().writeConcern('majority')

// same as majority. keep the same behavior with read concern/read preference
mquery().writeConcern('m')

// if the tag set happens to be 'm', use .writeConcern({ w: 'm' }) instead.
mquery().writeConcern('tagSetName')
mquery().w(1) // w is alias of writeConcern
```

The special case is that write concern accepts `object` and it will parse the object to the underlying options correctly. Also, `.w('m')` is alias of `.w('majority')`. Mongoose does not has this implementation.

## Add `r` as alias of `readConcern`
as `w` is for `writeConcern`

## Add `setReadPreference` as alias of `read`

`mquery` use `.read()` to set read preference. However, `node-mongodb-native` [has different meaning](http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#read)
IMO, this method is for internal use. I think it's okay to overwrite this behavior.

`node-mongodb-native` uses [setReadPreference](http://mongodb.github.io/node-mongodb-native/3.1/api/Cursor.html#setReadPreference) to specify read preference.

## Add `hint` test

## Add findOneAndDelete alias of findOneAndRemove