### PR TITLE
replace regexp-clone with native functionality

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,8 +4,6 @@
  * Module dependencies.
  */
 
-const RegExpClone = require('regexp-clone');
-
 const specialProperties = ['__proto__', 'constructor', 'prototype'];
 
 /**
@@ -45,7 +43,7 @@ const clone = exports.clone = function clone(obj, options) {
       return new obj.constructor(+obj);
 
     if ('RegExp' === obj.constructor.name)
-      return RegExpClone(obj);
+      return RegExp(obj.source, obj.flags);
 
     if ('Buffer' === obj.constructor.name)
       return Buffer.from(obj);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ const clone = exports.clone = function clone(obj, options) {
       return new obj.constructor(+obj);
 
     if ('RegExp' === obj.constructor.name)
-      return RegExp(obj.source, obj.flags);
+      return new RegExp(obj.source, obj.flags);
 
     if ('Buffer' === obj.constructor.name)
       return Buffer.from(obj);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,7 +43,7 @@ const clone = exports.clone = function clone(obj, options) {
       return new obj.constructor(+obj);
 
     if ('RegExp' === obj.constructor.name)
-      return new RegExp(obj.source, obj.flags);
+      return new RegExp(obj);
 
     if ('Buffer' === obj.constructor.name)
       return Buffer.from(obj);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "debug": "4.x",
-    "regexp-clone": "^1.0.0"
+    "debug": "4.x"
   },
   "devDependencies": {
     "eslint": "8.x",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -42,6 +42,7 @@ describe('lib/utils', function() {
 
       const clonedRE = utils.clone(sampleRE);
 
+      assert.ok(clonedRE !== sampleRE);
       assert.ok(clonedRE instanceof RegExp);
       assert.ok(clonedRE.source === 'a');
       assert.ok(clonedRE.flags === 'giy');

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -37,6 +37,26 @@ describe('lib/utils', function() {
       done();
     });
 
+    it('clones RegExp', function(done) {
+      const sampleRE = /a/giy;
+
+      const clonedRE = utils.clone(sampleRE);
+
+      assert.ok(clonedRE instanceof RegExp);
+      assert.ok(clonedRE.source === 'a');
+      assert.ok(clonedRE.flags === 'giy');
+      done();
+    });
+
+    it('clones Buffer', function(done) {
+      const buf1 = Buffer.alloc(10);
+
+      const buf2 = utils.clone(buf1);
+
+      assert.ok(buf2 instanceof Buffer);
+      done();
+    });
+
     it('does not clone constructors named ObjectIdd', function(done) {
       function ObjectIdd(id) {
         this.id = id;


### PR DESCRIPTION
I think we dont need to preserve lastIndex.. so we can just simply use new RegExp(source, flags) to clone the RegExp...
and even if, we would need only to assign lastIndex from the old regex to the new one...