### PR TITLE
ci: remove unsupported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
   - "12"
 matrix:
   include:


### PR DESCRIPTION
Just realized, while checking the package, that travis still runs ci for unsupported versions. Not sure i might just add 14 and 16 instead.